### PR TITLE
Add JFrog CLI to path even if cached

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ export class Utils {
         let fileName: string = Utils.getCliExecutableName();
         let cliDir: string = toolCache.find(fileName, version);
         if (cliDir) {
+            core.addPath(cliDir);
             return path.join(cliDir, fileName);
         }
         let url: string = Utils.getCliUrl(version, fileName);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

When the JFrog CLI tool is loaded from cache, we should also add it to the path.
Possibly caused https://github.com/jfrog/setup-jfrog-cli/issues/20.