### PR TITLE
Update CLI to 1.46.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
               env:
                   JF_ARTIFACTORY_LOCAL: eyJ2ZXJzaW9uIjoxLCJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvYXJ0aWZhY3RvcnkvIiwidXNlciI6ImFkbWluIiwicGFzc3dvcmQiOiJBUEI3REVaUlBpSHFIRFRRb2tMa3g5aGh6S1QiLCJzZXJ2ZXJJZCI6ImxvY2FsIn0=
             - name: Sanity # Check that the correct CLI downloaded and local server successfully configured
-              run: jfrog rt c show local
+              run: jfrog c show local
             - name: Check build URL
               uses: wei/curl@master
               with:

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'JFrog'
 inputs:
     version:
         description: 'JFrog CLI Version'
-        default: '1.46.1'
+        default: '1.46.4'
         required: false
 runs:
     using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'JFrog'
 inputs:
     version:
         description: 'JFrog CLI Version'
-        default: '1.44.0'
+        default: '1.46.1'
         required: false
 runs:
     using: 'node12'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,7 +89,7 @@ class Utils {
             let version = core.getInput(Utils.CLI_VERSION_ARG);
             let useOldConfig = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
             if (useOldConfig) {
-                core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.1 or above.');
+                core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.4 or above.');
             }
             for (let serverToken of Utils.getServerTokens()) {
                 let importCmd = useOldConfig ? ['rt', 'c', 'import', serverToken] : ['c', 'import', serverToken];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,8 +86,14 @@ class Utils {
     }
     static configArtifactoryServers(cliPath) {
         return __awaiter(this, void 0, void 0, function* () {
+            let version = core.getInput(Utils.CLI_VERSION_ARG);
+            let useNewConfig = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
+            if (!useNewConfig) {
+                core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.1 or above.');
+            }
             for (let serverToken of Utils.getServerTokens()) {
-                yield Utils.runCli(cliPath, ['c', 'import', serverToken]);
+                let importCmd = useNewConfig ? ['c', 'import', serverToken] : ['rt', 'c', 'import', serverToken];
+                yield Utils.runCli(cliPath, importCmd);
             }
         });
     }
@@ -121,5 +127,6 @@ class Utils {
 exports.Utils = Utils;
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 Utils.SERVER_TOKEN_PREFIX = /^JF_ARTIFACTORY_.*$/;
+Utils.NEW_CONFIG_CLI_VERSION = '1.45.0';
 Utils.CLI_VERSION_ARG = 'version';
-Utils.MIN_CLI_VERSION = '1.45.0';
+Utils.MIN_CLI_VERSION = '1.29.0';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,12 +87,12 @@ class Utils {
     static configArtifactoryServers(cliPath) {
         return __awaiter(this, void 0, void 0, function* () {
             let version = core.getInput(Utils.CLI_VERSION_ARG);
-            let useNewConfig = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
-            if (!useNewConfig) {
+            let useOldConfig = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
+            if (useOldConfig) {
                 core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.1 or above.');
             }
             for (let serverToken of Utils.getServerTokens()) {
-                let importCmd = useNewConfig ? ['c', 'import', serverToken] : ['rt', 'c', 'import', serverToken];
+                let importCmd = useOldConfig ? ['rt', 'c', 'import', serverToken] : ['c', 'import', serverToken];
                 yield Utils.runCli(cliPath, importCmd);
             }
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,6 +50,7 @@ class Utils {
                 return path.join(cliDir, fileName);
             }
             let url = Utils.getCliUrl(version, fileName);
+            core.debug('Downloading JFrog CLI from ' + url);
             let downloadDir = yield toolCache.downloadTool(url);
             cliDir = yield toolCache.cacheFile(downloadDir, fileName, fileName, version);
             let cliPath = path.join(cliDir, fileName);
@@ -61,8 +62,8 @@ class Utils {
         });
     }
     static getCliUrl(version, fileName) {
-        let bintrayPackage = 'jfrog-cli-' + Utils.getArchitecture();
-        return ('https://api.bintray.com/content/jfrog/jfrog-cli-go/' + version + '/' + bintrayPackage + '/' + fileName + '?bt_package=' + bintrayPackage);
+        let architecture = 'jfrog-cli-' + Utils.getArchitecture();
+        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/' + version + '/' + architecture + '/' + fileName;
     }
     static getServerTokens() {
         return Object.keys(process.env)
@@ -86,7 +87,7 @@ class Utils {
     static configArtifactoryServers(cliPath) {
         return __awaiter(this, void 0, void 0, function* () {
             for (let serverToken of Utils.getServerTokens()) {
-                yield Utils.runCli(cliPath, ['rt', 'c', 'import', serverToken]);
+                yield Utils.runCli(cliPath, ['c', 'import', serverToken]);
             }
         });
     }
@@ -121,4 +122,4 @@ exports.Utils = Utils;
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 Utils.SERVER_TOKEN_PREFIX = /^JF_ARTIFACTORY_.*$/;
 Utils.CLI_VERSION_ARG = 'version';
-Utils.MIN_CLI_VERSION = '1.29.0';
+Utils.MIN_CLI_VERSION = '1.45.0';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,6 +127,7 @@ class Utils {
 exports.Utils = Utils;
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 Utils.SERVER_TOKEN_PREFIX = /^JF_ARTIFACTORY_.*$/;
+// Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
 Utils.NEW_CONFIG_CLI_VERSION = '1.45.0';
 Utils.CLI_VERSION_ARG = 'version';
 Utils.MIN_CLI_VERSION = '1.29.0';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,12 +64,12 @@ export class Utils {
 
     public static async configArtifactoryServers(cliPath: string) {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
-        let useNewConfig: boolean = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
-        if (!useNewConfig) {
+        let useOldConfig: boolean = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
+        if (useOldConfig) {
             core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.1 or above.');
         }
         for (let serverToken of Utils.getServerTokens()) {
-            let importCmd: string[] = useNewConfig ? ['c', 'import', serverToken] : ['rt', 'c', 'import', serverToken];
+            let importCmd: string[] = useOldConfig ? ['rt', 'c', 'import', serverToken] : ['c', 'import', serverToken];
             await Utils.runCli(cliPath, importCmd);
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import * as semver from 'semver';
 export class Utils {
     public static readonly USER_AGENT: string = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
     public static readonly SERVER_TOKEN_PREFIX: RegExp = /^JF_ARTIFACTORY_.*$/;
+    // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
     public static readonly NEW_CONFIG_CLI_VERSION: string = '1.45.0';
     public static readonly CLI_VERSION_ARG: string = 'version';
     public static readonly MIN_CLI_VERSION: string = '1.29.0';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ export class Utils {
     public static readonly USER_AGENT: string = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
     public static readonly SERVER_TOKEN_PREFIX: RegExp = /^JF_ARTIFACTORY_.*$/;
     public static readonly CLI_VERSION_ARG: string = 'version';
-    public static readonly MIN_CLI_VERSION: string = '1.29.0';
+    public static readonly MIN_CLI_VERSION: string = '1.45.0';
 
     public static async downloadCli(): Promise<string> {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
@@ -24,6 +24,7 @@ export class Utils {
             return path.join(cliDir, fileName);
         }
         let url: string = Utils.getCliUrl(version, fileName);
+        core.debug('Downloading JFrog CLI from ' + url);
         let downloadDir: string = await toolCache.downloadTool(url);
         cliDir = await toolCache.cacheFile(downloadDir, fileName, fileName, version);
         let cliPath: string = path.join(cliDir, fileName);
@@ -35,10 +36,8 @@ export class Utils {
     }
 
     public static getCliUrl(version: string, fileName: string): string {
-        let bintrayPackage: string = 'jfrog-cli-' + Utils.getArchitecture();
-        return (
-            'https://api.bintray.com/content/jfrog/jfrog-cli-go/' + version + '/' + bintrayPackage + '/' + fileName + '?bt_package=' + bintrayPackage
-        );
+        let architecture: string = 'jfrog-cli-' + Utils.getArchitecture();
+        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/' + version + '/' + architecture + '/' + fileName;
     }
 
     public static getServerTokens(): string[] {
@@ -64,7 +63,7 @@ export class Utils {
 
     public static async configArtifactoryServers(cliPath: string) {
         for (let serverToken of Utils.getServerTokens()) {
-            await Utils.runCli(cliPath, ['rt', 'c', 'import', serverToken]);
+            await Utils.runCli(cliPath, ['c', 'import', serverToken]);
         }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,7 +66,7 @@ export class Utils {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
         let useOldConfig: boolean = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
         if (useOldConfig) {
-            core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.1 or above.');
+            core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.4 or above.');
         }
         for (let serverToken of Utils.getServerTokens()) {
             let importCmd: string[] = useOldConfig ? ['rt', 'c', 'import', serverToken] : ['c', 'import', serverToken];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,8 +9,9 @@ import * as semver from 'semver';
 export class Utils {
     public static readonly USER_AGENT: string = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
     public static readonly SERVER_TOKEN_PREFIX: RegExp = /^JF_ARTIFACTORY_.*$/;
+    public static readonly NEW_CONFIG_CLI_VERSION: string = '1.45.0';
     public static readonly CLI_VERSION_ARG: string = 'version';
-    public static readonly MIN_CLI_VERSION: string = '1.45.0';
+    public static readonly MIN_CLI_VERSION: string = '1.29.0';
 
     public static async downloadCli(): Promise<string> {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
@@ -62,8 +63,14 @@ export class Utils {
     }
 
     public static async configArtifactoryServers(cliPath: string) {
+        let version: string = core.getInput(Utils.CLI_VERSION_ARG);
+        let useNewConfig: boolean = semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
+        if (!useNewConfig) {
+            core.warning('JFrog CLI ' + version + ' on Setup JFrog CLI GitHub Action is deprecated. Please use version 1.46.1 or above.');
+        }
         for (let serverToken of Utils.getServerTokens()) {
-            await Utils.runCli(cliPath, ['c', 'import', serverToken]);
+            let importCmd: string[] = useNewConfig ? ['c', 'import', serverToken] : ['rt', 'c', 'import', serverToken];
+            await Utils.runCli(cliPath, importCmd);
         }
     }
 

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -27,38 +27,13 @@ describe('JFrog CLI action Tests', () => {
                 'win32' as NodeJS.Platform,
                 'amd64',
                 'jfrog.exe',
-                'https://api.bintray.com/content/jfrog/jfrog-cli-go/1.2.3/jfrog-cli-windows-amd64/jfrog.exe?bt_package=jfrog-cli-windows-amd64',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-windows-amd64/jfrog.exe',
             ],
-            [
-                'darwin' as NodeJS.Platform,
-                'amd64',
-                'jfrog',
-                'https://api.bintray.com/content/jfrog/jfrog-cli-go/1.2.3/jfrog-cli-mac-386/jfrog?bt_package=jfrog-cli-mac-386',
-            ],
-            [
-                'linux' as NodeJS.Platform,
-                'amd64',
-                'jfrog',
-                'https://api.bintray.com/content/jfrog/jfrog-cli-go/1.2.3/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64',
-            ],
-            [
-                'linux' as NodeJS.Platform,
-                'arm64',
-                'jfrog',
-                'https://api.bintray.com/content/jfrog/jfrog-cli-go/1.2.3/jfrog-cli-linux-arm64/jfrog?bt_package=jfrog-cli-linux-arm64',
-            ],
-            [
-                'linux' as NodeJS.Platform,
-                '386',
-                'jfrog',
-                'https://api.bintray.com/content/jfrog/jfrog-cli-go/1.2.3/jfrog-cli-linux-386/jfrog?bt_package=jfrog-cli-linux-386',
-            ],
-            [
-                'linux' as NodeJS.Platform,
-                'arm',
-                'jfrog',
-                'https://api.bintray.com/content/jfrog/jfrog-cli-go/1.2.3/jfrog-cli-linux-arm/jfrog?bt_package=jfrog-cli-linux-arm',
-            ],
+            ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-mac-386/jfrog'],
+            ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-amd64/jfrog'],
+            ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm64/jfrog'],
+            ['linux' as NodeJS.Platform, '386', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-386/jfrog'],
+            ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm/jfrog'],
         ];
 
         test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Upgrade CLI to 1.46.4
* Upgrade minimal CLI version to 1.45.0, due to the new configuration command.
* Download CLI from 'releases.jfrog.io' instead of Bintray - fix tests.
* Update config import command to match the required in the latest versions.