### PR TITLE
Change build-number and build-url

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,11 +77,11 @@ class Utils {
         if (buildNameEnv) {
             core.exportVariable('JFROG_CLI_BUILD_NAME', buildNameEnv);
         }
-        let buildNumberEnv = process.env.GITHUB_SHA;
+        let buildNumberEnv = process.env.GITHUB_RUN_NUMBER;
         if (buildNumberEnv) {
             core.exportVariable('JFROG_CLI_BUILD_NUMBER', buildNumberEnv);
         }
-        core.exportVariable('JFROG_CLI_BUILD_URL', 'https://github.com/' + process.env.GITHUB_REPOSITORY + '/commit/' + buildNumberEnv + '/checks');
+        core.exportVariable('JFROG_CLI_BUILD_URL', process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID);
         core.exportVariable('JFROG_CLI_USER_AGENT', Utils.USER_AGENT);
     }
     static configArtifactoryServers(cliPath) {

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -5,7 +5,7 @@
 
 checkEnv('JFROG_CLI_OFFER_CONFIG', 'false');
 checkEnv('JFROG_CLI_BUILD_NAME', process.env.GITHUB_WORKFLOW);
-checkEnv('JFROG_CLI_BUILD_NUMBER', process.env.GITHUB_SHA);
+checkEnv('JFROG_CLI_BUILD_NUMBER', process.env.GITHUB_RUN_NUMBER);
 checkEnv('JFROG_CLI_ENV_EXCLUDE', '*password*;*secret*;*key*;*token*;JF_ARTIFACTORY_*');
 checkEnv('JFROG_CLI_USER_AGENT', 'setup-jfrog-cli-github-action/' + require('../package.json').version)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,11 +55,14 @@ export class Utils {
         if (buildNameEnv) {
             core.exportVariable('JFROG_CLI_BUILD_NAME', buildNameEnv);
         }
-        let buildNumberEnv: string | undefined = process.env.GITHUB_SHA;
+        let buildNumberEnv: string | undefined = process.env.GITHUB_RUN_NUMBER;
         if (buildNumberEnv) {
             core.exportVariable('JFROG_CLI_BUILD_NUMBER', buildNumberEnv);
         }
-        core.exportVariable('JFROG_CLI_BUILD_URL', 'https://github.com/' + process.env.GITHUB_REPOSITORY + '/commit/' + buildNumberEnv + '/checks');
+        core.exportVariable(
+            'JFROG_CLI_BUILD_URL',
+            process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID
+        );
         core.exportVariable('JFROG_CLI_USER_AGENT', Utils.USER_AGENT);
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Resolves #10 

* Instead of commit SHA, use the run number as the build number.
 >  GITHUB_RUN_NUMBER - A unique number for each run  of a particular workflow in a repository. This number begins at 1 for  the workflow's first run, and increments with each new run. This number  does not change if you re-run the workflow run.


* Use https://github.com/:owner/:repo/actions/runs/:run-id` as the build URL. 
Current build URL is https://github.com/:owner/:repo/commit/:sha/checks which is not accurate if you run rebuild.