### PR TITLE
Be able to use version with a major of 2

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export class Utils {
 
     public static getCliUrl(version: string, fileName: string): string {
         let architecture: string = 'jfrog-cli-' + Utils.getArchitecture();
-        let major: string = version.splt('.')[0];
+        let major: string = version.split('.')[0];
         return 'https://releases.jfrog.io/artifactory/jfrog-cli/v' + major + '/' + version + '/' + architecture + '/' + fileName;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,8 @@ export class Utils {
 
     public static getCliUrl(version: string, fileName: string): string {
         let architecture: string = 'jfrog-cli-' + Utils.getArchitecture();
-        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/' + version + '/' + architecture + '/' + fileName;
+        let major: string = version.splt('.')[0];
+        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v' + major + '/' + version + '/' + architecture + '/' + fileName;
     }
 
     public static getServerTokens(): string[] {


### PR DESCRIPTION
As the administrator of the CI/CD setting up in my company, I am testing how JIRA, GitHub and JFrog are working together... My first feeling was that configuration is not so easy but, more over that, I noticed that when I used JFrog CLI with a GitHub Action as mentioned by the documentation is producing quiet different results from the JFrog CLI installed into my own local machine. After some deep investigation and lot of "Re run failed jobs" I finally found out that I was unable to use the current version (i.e. 2.3.0) because of a simple hard coded var.

I propose here a quick fix for that :)
 
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
