### PR TITLE
Update version to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v1
-            - name: Update v1 tag
-              run: git tag -f v1
+            - name: Update v2 tag
+              run: git tag -f v2
             - name: Push changes
               uses: ad-m/github-push-action@master
               with:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ All build related operations will be automatically recorded with the *Workflow N
 ## General
 
 ```yml
-- uses: jfrog/setup-jfrog-cli@v1
+- uses: jfrog/setup-jfrog-cli@v2
 - run: jfrog --version
 ```
 
@@ -32,7 +32,7 @@ To use the saved Artifactory server configuration in the workflow, all you need 
 The secret should be exposed as an environment variable with the *JF_ARTIFACTORY_* prefix.
 Here's how you do this:
 ```yml
-- uses: jfrog/setup-jfrog-cli@v1
+- uses: jfrog/setup-jfrog-cli@v2
   env:
     JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
 - run: |
@@ -44,7 +44,7 @@ as the *JF_ARTIFACTORY_1* environment variable. That's it - the ping command wil
 
 If you have multiple Artifactory servers configured as secrets, you can use all of the in the workflow as follows:
 ```yml
-- uses: jfrog/setup-jfrog-cli@v1
+- uses: jfrog/setup-jfrog-cli@v2
   env:
     JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
     JF_ARTIFACTORY_2: ${{ secrets.JF_ARTIFACTORY_SECRET_2 }}
@@ -79,7 +79,7 @@ are registered as the build artifacts.
 By default the JFrog CLI version set in [action.yml](https://github.com/jfrog/setup-jfrog-cli/blob/master/action.yml) is used. To set a specific version, add the *version* input as follows:
 
 ```yml
-- uses: jfrog/setup-jfrog-cli@v1
+- uses: jfrog/setup-jfrog-cli@v2
   with:
     version: X.Y.Z
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'JFrog'
 inputs:
     version:
         description: 'JFrog CLI Version'
-        default: '1.51.1'
+        default: '2.3.0'
         required: false
 runs:
     using: 'node12'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "setup-jfrog-cli",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "setup-jfrog-cli",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "private": true,
     "description": "Setup JFrog CLI in GitHub Actions",
     "main": "lib/main.js",

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -20,7 +20,7 @@ describe('JFrog CLI action Tests', () => {
         expect(serverTokens).toStrictEqual(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2']);
     });
 
-    describe('JFrog CLI URL Tests', () => {
+    describe('JFrog CLI V1 URL Tests', () => {
         const myOs: jest.Mocked<typeof os> = os as any;
         let cases: string[][] = [
             [
@@ -40,6 +40,30 @@ describe('JFrog CLI action Tests', () => {
             myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
             myOs.arch.mockImplementation(() => arch);
             let cliUrl: string = Utils.getCliUrl('1.2.3', fileName);
+            expect(cliUrl).toBe(expectedUrl);
+        });
+    });
+
+    describe('JFrog CLI V2 URL Tests', () => {
+        const myOs: jest.Mocked<typeof os> = os as any;
+        let cases: string[][] = [
+            [
+                'win32' as NodeJS.Platform,
+                'amd64',
+                'jfrog.exe',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-windows-amd64/jfrog.exe',
+            ],
+            ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-mac-386/jfrog'],
+            ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-amd64/jfrog'],
+            ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm64/jfrog'],
+            ['linux' as NodeJS.Platform, '386', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-386/jfrog'],
+            ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm/jfrog'],
+        ];
+
+        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
+            myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
+            myOs.arch.mockImplementation(() => arch);
+            let cliUrl: string = Utils.getCliUrl('2.3.4', fileName);
             expect(cliUrl).toBe(expectedUrl);
         });
     });


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Release to v2 tag. In this tag, use JFrog CLI v2 by default.
* Update version to 2.0.0.
* Add JFrog CLI V2 URL Tests.