### PR TITLE
Custom cli url

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ By default the JFrog CLI version set in [action.yml](https://github.com/jfrog/se
 | Important: Only JFrog CLI versions 1.29.0 or above are supported. |
 | --- |
 
+## Setting JFrog remote url
+By default the JFrog CLI is downloaded from https://releases.jfrog.io/artifactory/jfrog-cli but you can specify a different url and download the cli from a remote repository in a locally hosted instance of artifactory. To set a specific remote url, add the *cli_url* input as follows:
+
+```yml
+- uses: jfrog/setup-jfrog-cli@v2
+  with:
+    cli_url: https://artifactory.mycompany.com/artifactory/jfrog-cli
+```
+
 ## Example projects
 To help you get started, you can use [these](https://github.com/jfrog/project-examples/tree/master/github-action-examples) sample projects on GitHub.
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
         description: 'JFrog CLI Version'
         default: '2.3.0'
         required: false
+    cli_url:
+        description: 'URL to JFrog cli'
+        default: 'https://releases.jfrog.io/artifactory/jfrog-cli'
+        required: false
 runs:
     using: 'node12'
     main: 'lib/main.js'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,6 +39,7 @@ const semver = __importStar(require("semver"));
 class Utils {
     static downloadCli() {
         return __awaiter(this, void 0, void 0, function* () {
+            let cli_url = core.getInput(Utils.CLI_URL);
             let version = core.getInput(Utils.CLI_VERSION_ARG);
             if (semver.lt(version, this.MIN_CLI_VERSION)) {
                 throw new Error('Requested to download JFrog CLI version ' + version + ' but must be at least ' + this.MIN_CLI_VERSION);
@@ -49,7 +50,7 @@ class Utils {
                 core.addPath(cliDir);
                 return path.join(cliDir, fileName);
             }
-            let url = Utils.getCliUrl(version, fileName);
+            let url = Utils.getCliUrl(cli_url, version, fileName);
             core.debug('Downloading JFrog CLI from ' + url);
             let downloadDir = yield toolCache.downloadTool(url);
             cliDir = yield toolCache.cacheFile(downloadDir, fileName, fileName, version);
@@ -61,10 +62,10 @@ class Utils {
             return cliPath;
         });
     }
-    static getCliUrl(version, fileName) {
+    static getCliUrl(cli_url, version, fileName) {
         let architecture = 'jfrog-cli-' + Utils.getArchitecture();
         let major = version.split('.')[0];
-        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v' + major + '/' + version + '/' + architecture + '/' + fileName;
+        return cli_url + '/v' + major + '/' + version + '/' + architecture + '/' + fileName;
     }
     static getServerTokens() {
         return Object.keys(process.env)
@@ -149,4 +150,5 @@ Utils.SERVER_TOKEN_PREFIX = /^JF_ARTIFACTORY_.*$/;
 // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
 Utils.NEW_CONFIG_CLI_VERSION = '1.45.0';
 Utils.CLI_VERSION_ARG = 'version';
+Utils.CLI_URL = 'cli_url';
 Utils.MIN_CLI_VERSION = '1.29.0';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,11 @@ export class Utils {
     // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
     public static readonly NEW_CONFIG_CLI_VERSION: string = '1.45.0';
     public static readonly CLI_VERSION_ARG: string = 'version';
+    public static readonly CLI_URL: string = 'cli_url';
     public static readonly MIN_CLI_VERSION: string = '1.29.0';
 
     public static async downloadCli(): Promise<string> {
+        let cli_url: string = core.getInput(Utils.CLI_URL);
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
         if (semver.lt(version, this.MIN_CLI_VERSION)) {
             throw new Error('Requested to download JFrog CLI version ' + version + ' but must be at least ' + this.MIN_CLI_VERSION);
@@ -25,7 +27,7 @@ export class Utils {
             core.addPath(cliDir);
             return path.join(cliDir, fileName);
         }
-        let url: string = Utils.getCliUrl(version, fileName);
+        let url: string = Utils.getCliUrl(cli_url, version, fileName);
         core.debug('Downloading JFrog CLI from ' + url);
         let downloadDir: string = await toolCache.downloadTool(url);
         cliDir = await toolCache.cacheFile(downloadDir, fileName, fileName, version);
@@ -37,10 +39,10 @@ export class Utils {
         return cliPath;
     }
 
-    public static getCliUrl(version: string, fileName: string): string {
+    public static getCliUrl(cli_url: string, version: string, fileName: string): string {
         let architecture: string = 'jfrog-cli-' + Utils.getArchitecture();
         let major: string = version.split('.')[0];
-        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v' + major + '/' + version + '/' + architecture + '/' + fileName;
+        return cli_url + '/v' + major + '/' + version + '/' + architecture + '/' + fileName;
     }
 
     public static getServerTokens(): string[] {

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -27,19 +27,50 @@ describe('JFrog CLI action Tests', () => {
                 'win32' as NodeJS.Platform,
                 'amd64',
                 'jfrog.exe',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
                 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-windows-amd64/jfrog.exe',
             ],
-            ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-mac-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-amd64/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm64/jfrog'],
-            ['linux' as NodeJS.Platform, '386', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm/jfrog'],
+            [
+                'darwin' as NodeJS.Platform,
+                'amd64',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-mac-386/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                'amd64',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-amd64/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                'arm64',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm64/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                '386',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-386/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                'arm',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm/jfrog',
+            ],
         ];
 
-        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
+        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, cli_url, expectedUrl) => {
             myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
             myOs.arch.mockImplementation(() => arch);
-            let cliUrl: string = Utils.getCliUrl('1.2.3', fileName);
+            let cliUrl: string = Utils.getCliUrl(cli_url, '1.2.3', fileName);
             expect(cliUrl).toBe(expectedUrl);
         });
     });
@@ -51,19 +82,50 @@ describe('JFrog CLI action Tests', () => {
                 'win32' as NodeJS.Platform,
                 'amd64',
                 'jfrog.exe',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
                 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-windows-amd64/jfrog.exe',
             ],
-            ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-mac-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-amd64/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm64/jfrog'],
-            ['linux' as NodeJS.Platform, '386', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm/jfrog'],
+            [
+                'darwin' as NodeJS.Platform,
+                'amd64',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-mac-386/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                'amd64',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-amd64/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                'arm64',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm64/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                '386',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-386/jfrog',
+            ],
+            [
+                'linux' as NodeJS.Platform,
+                'arm',
+                'jfrog',
+                'https://releases.jfrog.io/artifactory/jfrog-cli',
+                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm/jfrog',
+            ],
         ];
 
-        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
+        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, cli_url, expectedUrl) => {
             myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
             myOs.arch.mockImplementation(() => arch);
-            let cliUrl: string = Utils.getCliUrl('2.3.4', fileName);
+            let cliUrl: string = Utils.getCliUrl(cli_url, '2.3.4', fileName);
             expect(cliUrl).toBe(expectedUrl);
         });
     });


### PR DESCRIPTION
This adds the ability to use a different url to download the jfrog cli incase your build agents have limited or no internet access

- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----