### PR TITLE
Allow downloading CLI from Artifactory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "args": [
+                "--runInBand"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "files.exclude": {
+        "dist": true, // set this to true to hide the "dist" folder with the compiled JS files
+        "node_modules": true,
+        "coverage": true
+    },
+    "search.exclude": {
+        "dist": true // set this to false to include "dist" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off",
+    "workbench.editor.enablePreview": false,
+    "workbench.editor.enablePreviewFromQuickOpen": false,
+    "workbench.editor.showTabs": true,
+    "files.autoSave": "afterDelay"
+}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ It is also possible to set the latest JFrog CLI version by adding the *version* 
 | Important: Only JFrog CLI versions 1.29.0 or above are supported. |
 | --- |
 
+## Downloading JFrog CLI From JFrog Artifactory
+If your agent has no internet access, you can configure the workflow to download JFrog CLI from a JFrog Artifactory instance, which is configured to proxy the download repository:
+1. Create a remote repository in Artifactory. Name the repository jfrog-cli-remote and set its URL to https://releases.jfrog.io/artifactory/jfrog-cli/
+2. Set *download-repository* input to jfrog-cli-remote:
+    ```yml
+    - uses: jfrog/setup-jfrog-cli@v2
+      with:
+        download-repository: jfrog-cli-remote
+    ```
+
 ## Example projects
 To help you get started, you can use [these](https://github.com/jfrog/project-examples/tree/master/github-action-examples) sample projects on GitHub.
 

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,18 @@
-name: 'Setup JFrog CLI'
-description: 'Install and configure JFrog CLI.'
-author: 'JFrog'
+name: "Setup JFrog CLI"
+description: "Install and configure JFrog CLI."
+author: "JFrog"
 inputs:
     version:
-        description: 'JFrog CLI Version'
-        default: '2.14.0'
+        description: "JFrog CLI Version"
+        default: "2.14.0"
+        required: false
+    download-repository:
+        description: "Remote repository in Artifactory pointing to 'https://releases.jfrog.io/artifactory/jfrog-cli'. Use this parameter in case you don't have an Internet access."
         required: false
 runs:
-    using: 'node12'
-    main: 'lib/main.js'
-    post: 'lib/cleanup.js'
+    using: "node12"
+    main: "lib/main.js"
+    post: "lib/cleanup.js"
 branding:
-    icon: 'terminal'
-    color: 'green'
+    icon: "terminal"
+    color: "green"

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,7 +46,7 @@ class Utils {
             let version = core.getInput(Utils.CLI_VERSION_ARG);
             let cliRemote = core.getInput(Utils.CLI_REMOTE_ARG);
             let major = version.split('.')[0];
-            if (version === this.LATEST_CLI_VERSION_ARG) {
+            if (version === this.LATEST_CLI_VERSION) {
                 version = Utils.LATEST_RELEASE_VERSION;
                 major = '2';
             }
@@ -200,7 +200,7 @@ class Utils {
     }
     /**
      * If repository input was set, extract CLI download details from the first JF_ENV_* environment variable.
-     * @param repository - Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli/
+     * @param repository - Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli/. If empty, use the default download details.
      * @returns the download details.
      */
     static extractDownloadDetails(repository) {
@@ -222,7 +222,7 @@ class Utils {
             }
             return results;
         }
-        throw new Error(`'download-repository' input provided, but no Artifactory server found`);
+        throw new Error(`'download-repository' input provided, but no Artifactory server found. Hint - make sure an environment variable with the JF_EN_ prefix is configured.`);
     }
     /**
      * Return true if should use 'jfrog rt c' instead of 'jfrog c'.
@@ -230,7 +230,7 @@ class Utils {
      */
     static useOldConfig() {
         let version = core.getInput(Utils.CLI_VERSION_ARG);
-        if (version === this.LATEST_CLI_VERSION_ARG) {
+        if (version === this.LATEST_CLI_VERSION) {
             return false;
         }
         return semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
@@ -239,16 +239,25 @@ class Utils {
 exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
+// Default artifactory URL and repository for downloading JFrog CLI
 Utils.DEFAULT_DOWNLOAD_DETAILS = {
     artifactoryUrl: 'https://releases.jfrog.io/artifactory',
     repository: 'jfrog-cli',
 };
+// The old JF_ARTIFACTORY_* prefix for server tokens
 Utils.SERVER_TOKEN_LEGACY_PREFIX = /^JF_ARTIFACTORY_.*$/;
+// The JF_ENV_* prefix for server tokens
 Utils.SERVER_TOKEN_PREFIX = /^JF_ENV_.*$/;
 // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
 Utils.NEW_CONFIG_CLI_VERSION = '1.45.0';
-Utils.CLI_VERSION_ARG = 'version';
+// Minimum JFrog CLI version supported
 Utils.MIN_CLI_VERSION = '1.29.0';
-Utils.LATEST_CLI_VERSION_ARG = 'latest';
+// The value in "version" argument to set to get the latest JFrog CLI version
+Utils.LATEST_CLI_VERSION = 'latest';
+// The value in the download URL to set to get the latest version
 Utils.LATEST_RELEASE_VERSION = '[RELEASE]';
+// Inputs
+// Version input
+Utils.CLI_VERSION_ARG = 'version';
+// Download repository input
 Utils.CLI_REMOTE_ARG = 'download-repository';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,6 +44,7 @@ class Utils {
     static addCliToPath() {
         return __awaiter(this, void 0, void 0, function* () {
             let version = core.getInput(Utils.CLI_VERSION_ARG);
+            let cliRemote = core.getInput(Utils.CLI_REMOTE_ARG);
             let major = version.split('.')[0];
             if (version === this.LATEST_CLI_VERSION_ARG) {
                 version = Utils.LATEST_RELEASE_VERSION;
@@ -59,9 +60,10 @@ class Utils {
                 return;
             }
             // Download JFrog CLI
-            let url = Utils.getCliUrl(major, version, jfrogFileName);
+            let downloadDetails = Utils.extractDownloadDetails(cliRemote);
+            let url = Utils.getCliUrl(major, version, jfrogFileName, downloadDetails);
             core.debug('Downloading JFrog CLI from ' + url);
-            let downloadDir = yield toolCache.downloadTool(url);
+            let downloadDir = yield toolCache.downloadTool(url, undefined, downloadDetails.auth);
             // Cache 'jf' and 'jfrog' executables
             yield this.cacheAndAddPath(downloadDir, version, jfFileName);
             yield this.cacheAndAddPath(downloadDir, version, jfrogFileName);
@@ -103,9 +105,9 @@ class Utils {
             core.addPath(cliDir);
         });
     }
-    static getCliUrl(major, version, fileName) {
+    static getCliUrl(major, version, fileName, downloadDetails) {
         let architecture = 'jfrog-cli-' + Utils.getArchitecture();
-        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v' + major + '/' + version + '/' + architecture + '/' + fileName;
+        return `${downloadDetails.artifactoryUrl}/${downloadDetails.repository}/v${major}/${version}/${architecture}/${fileName}`;
     }
     static getServerTokens() {
         let serverTokens = new Set(Object.keys(process.env)
@@ -197,6 +199,32 @@ class Utils {
         });
     }
     /**
+     * If repository input was set, extract CLI download details from the first JF_ENV_* environment variable.
+     * @param repository - Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli/
+     * @returns the download details.
+     */
+    static extractDownloadDetails(repository) {
+        if (repository === '') {
+            return Utils.DEFAULT_DOWNLOAD_DETAILS;
+        }
+        for (let serverToken of Utils.getServerTokens()) {
+            let serverObj = JSON.parse(Buffer.from(serverToken, 'base64').toString());
+            if (!serverObj || !serverObj.artifactoryUrl) {
+                continue;
+            }
+            let artifactoryUrl = serverObj.artifactoryUrl.replace(/\/$/, '');
+            let results = { artifactoryUrl, repository };
+            if (serverObj.user && serverObj.password) {
+                results.auth = 'Basic ' + Buffer.from(serverObj.user + ':' + serverObj.password).toString('base64');
+            }
+            else if (serverObj.accessToken) {
+                results.auth = 'Bearer ' + Buffer.from(serverObj.accessToken).toString('base64');
+            }
+            return results;
+        }
+        throw new Error(`'download-repository' input provided, but no Artifactory server found`);
+    }
+    /**
      * Return true if should use 'jfrog rt c' instead of 'jfrog c'.
      * @returns true if should use 'jfrog rt c' instead of 'jfrog c'.
      */
@@ -211,6 +239,10 @@ class Utils {
 exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
+Utils.DEFAULT_DOWNLOAD_DETAILS = {
+    artifactoryUrl: 'https://releases.jfrog.io/artifactory',
+    repository: 'jfrog-cli',
+};
 Utils.SERVER_TOKEN_LEGACY_PREFIX = /^JF_ARTIFACTORY_.*$/;
 Utils.SERVER_TOKEN_PREFIX = /^JF_ENV_.*$/;
 // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
@@ -219,3 +251,4 @@ Utils.CLI_VERSION_ARG = 'version';
 Utils.MIN_CLI_VERSION = '1.29.0';
 Utils.LATEST_CLI_VERSION_ARG = 'latest';
 Utils.LATEST_RELEASE_VERSION = '[RELEASE]';
+Utils.CLI_REMOTE_ARG = 'download-repository';

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "scripts": {
         "build": "tsc",
         "prepublishOnly": "npm prune --production && npm run build",
-        "format": "prettier --write **/*.ts",
-        "format-check": "prettier --check **/*.ts",
-        "lint": "eslint -c .eslintrc.js --ext .ts src",
+        "format": "npx prettier --write **/*.ts",
+        "format-check": "npx prettier --check **/*.ts",
+        "lint": "npx eslint -c .eslintrc.js --ext .ts src",
         "compile": "tsc",
         "postinstall": "npm run compile",
-        "test": "jest --colors",
-        "prepare": "husky install .husky"
+        "test": "npx jest --colors",
+        "prepare": "npx husky install .husky"
     },
     "repository": {
         "type": "git",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,26 +9,36 @@ import * as semver from 'semver';
 export class Utils {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     public static readonly USER_AGENT: string = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
+    // Default artifactory URL and repository for downloading JFrog CLI
     public static readonly DEFAULT_DOWNLOAD_DETAILS: DownloadDetails = {
         artifactoryUrl: 'https://releases.jfrog.io/artifactory',
         repository: 'jfrog-cli',
     } as DownloadDetails;
 
+    // The old JF_ARTIFACTORY_* prefix for server tokens
     private static readonly SERVER_TOKEN_LEGACY_PREFIX: RegExp = /^JF_ARTIFACTORY_.*$/;
+    // The JF_ENV_* prefix for server tokens
     private static readonly SERVER_TOKEN_PREFIX: RegExp = /^JF_ENV_.*$/;
     // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
     private static readonly NEW_CONFIG_CLI_VERSION: string = '1.45.0';
-    private static readonly CLI_VERSION_ARG: string = 'version';
+    // Minimum JFrog CLI version supported
     private static readonly MIN_CLI_VERSION: string = '1.29.0';
-    private static readonly LATEST_CLI_VERSION_ARG: string = 'latest';
+    // The value in "version" argument to set to get the latest JFrog CLI version
+    private static readonly LATEST_CLI_VERSION: string = 'latest';
+    // The value in the download URL to set to get the latest version
     private static readonly LATEST_RELEASE_VERSION: string = '[RELEASE]';
+
+    // Inputs
+    // Version input
+    private static readonly CLI_VERSION_ARG: string = 'version';
+    // Download repository input
     private static readonly CLI_REMOTE_ARG: string = 'download-repository';
 
     public static async addCliToPath() {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
         let cliRemote: string = core.getInput(Utils.CLI_REMOTE_ARG);
         let major: string = version.split('.')[0];
-        if (version === this.LATEST_CLI_VERSION_ARG) {
+        if (version === this.LATEST_CLI_VERSION) {
             version = Utils.LATEST_RELEASE_VERSION;
             major = '2';
         } else if (semver.lt(version, this.MIN_CLI_VERSION)) {
@@ -200,7 +210,7 @@ export class Utils {
 
     /**
      * If repository input was set, extract CLI download details from the first JF_ENV_* environment variable.
-     * @param repository - Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli/
+     * @param repository - Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli/. If empty, use the default download details.
      * @returns the download details.
      */
     public static extractDownloadDetails(repository: string): DownloadDetails {
@@ -221,7 +231,7 @@ export class Utils {
             }
             return results;
         }
-        throw new Error(`'download-repository' input provided, but no Artifactory server found`);
+        throw new Error(`'download-repository' input provided, but no Artifactory server found. Hint - make sure an environment variable with the JF_EN_ prefix is configured.`);
     }
 
     /**
@@ -230,7 +240,7 @@ export class Utils {
      */
     private static useOldConfig(): boolean {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
-        if (version === this.LATEST_CLI_VERSION_ARG) {
+        if (version === this.LATEST_CLI_VERSION) {
             return false;
         }
         return semver.lt(version, this.NEW_CONFIG_CLI_VERSION);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,18 +9,24 @@ import * as semver from 'semver';
 export class Utils {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     public static readonly USER_AGENT: string = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
-    public static readonly SERVER_TOKEN_LEGACY_PREFIX: RegExp = /^JF_ARTIFACTORY_.*$/;
-    public static readonly SERVER_TOKEN_PREFIX: RegExp = /^JF_ENV_.*$/;
-    // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
-    public static readonly NEW_CONFIG_CLI_VERSION: string = '1.45.0';
-    public static readonly CLI_VERSION_ARG: string = 'version';
-    public static readonly MIN_CLI_VERSION: string = '1.29.0';
-    public static readonly LATEST_CLI_VERSION_ARG: string = 'latest';
+    public static readonly DEFAULT_DOWNLOAD_DETAILS: DownloadDetails = {
+        artifactoryUrl: 'https://releases.jfrog.io/artifactory',
+        repository: 'jfrog-cli',
+    } as DownloadDetails;
 
+    private static readonly SERVER_TOKEN_LEGACY_PREFIX: RegExp = /^JF_ARTIFACTORY_.*$/;
+    private static readonly SERVER_TOKEN_PREFIX: RegExp = /^JF_ENV_.*$/;
+    // Since 1.45.0, 'jfrog rt c' command changed to 'jfrog c add'
+    private static readonly NEW_CONFIG_CLI_VERSION: string = '1.45.0';
+    private static readonly CLI_VERSION_ARG: string = 'version';
+    private static readonly MIN_CLI_VERSION: string = '1.29.0';
+    private static readonly LATEST_CLI_VERSION_ARG: string = 'latest';
     private static readonly LATEST_RELEASE_VERSION: string = '[RELEASE]';
+    private static readonly CLI_REMOTE_ARG: string = 'download-repository';
 
     public static async addCliToPath() {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
+        let cliRemote: string = core.getInput(Utils.CLI_REMOTE_ARG);
         let major: string = version.split('.')[0];
         if (version === this.LATEST_CLI_VERSION_ARG) {
             version = Utils.LATEST_RELEASE_VERSION;
@@ -37,9 +43,10 @@ export class Utils {
         }
 
         // Download JFrog CLI
-        let url: string = Utils.getCliUrl(major, version, jfrogFileName);
+        let downloadDetails: DownloadDetails = Utils.extractDownloadDetails(cliRemote);
+        let url: string = Utils.getCliUrl(major, version, jfrogFileName, downloadDetails);
         core.debug('Downloading JFrog CLI from ' + url);
-        let downloadDir: string = await toolCache.downloadTool(url);
+        let downloadDir: string = await toolCache.downloadTool(url, undefined, downloadDetails.auth);
 
         // Cache 'jf' and 'jfrog' executables
         await this.cacheAndAddPath(downloadDir, version, jfFileName);
@@ -83,9 +90,9 @@ export class Utils {
         core.addPath(cliDir);
     }
 
-    public static getCliUrl(major: string, version: string, fileName: string): string {
+    public static getCliUrl(major: string, version: string, fileName: string, downloadDetails: DownloadDetails): string {
         let architecture: string = 'jfrog-cli-' + Utils.getArchitecture();
-        return 'https://releases.jfrog.io/artifactory/jfrog-cli/v' + major + '/' + version + '/' + architecture + '/' + fileName;
+        return `${downloadDetails.artifactoryUrl}/${downloadDetails.repository}/v${major}/${version}/${architecture}/${fileName}`;
     }
 
     public static getServerTokens(): Set<string> {
@@ -192,6 +199,32 @@ export class Utils {
     }
 
     /**
+     * If repository input was set, extract CLI download details from the first JF_ENV_* environment variable.
+     * @param repository - Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli/
+     * @returns the download details.
+     */
+    public static extractDownloadDetails(repository: string): DownloadDetails {
+        if (repository === '') {
+            return Utils.DEFAULT_DOWNLOAD_DETAILS;
+        }
+        for (let serverToken of Utils.getServerTokens()) {
+            let serverObj: any = JSON.parse(Buffer.from(serverToken, 'base64').toString());
+            if (!serverObj || !serverObj.artifactoryUrl) {
+                continue;
+            }
+            let artifactoryUrl: string = serverObj.artifactoryUrl.replace(/\/$/, '');
+            let results: DownloadDetails = { artifactoryUrl, repository } as DownloadDetails;
+            if (serverObj.user && serverObj.password) {
+                results.auth = 'Basic ' + Buffer.from(serverObj.user + ':' + serverObj.password).toString('base64');
+            } else if (serverObj.accessToken) {
+                results.auth = 'Bearer ' + Buffer.from(serverObj.accessToken).toString('base64');
+            }
+            return results;
+        }
+        throw new Error(`'download-repository' input provided, but no Artifactory server found`);
+    }
+
+    /**
      * Return true if should use 'jfrog rt c' instead of 'jfrog c'.
      * @returns true if should use 'jfrog rt c' instead of 'jfrog c'.
      */
@@ -202,4 +235,10 @@ export class Utils {
         }
         return semver.lt(version, this.NEW_CONFIG_CLI_VERSION);
     }
+}
+
+export interface DownloadDetails {
+    artifactoryUrl: string;
+    repository: string;
+    auth: string;
 }

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,99 +1,141 @@
 import os from 'os';
-import { Utils } from '../src/utils';
+import { Utils, DownloadDetails } from '../src/utils';
 jest.mock('os');
 
-describe('JFrog CLI action Tests', () => {
-    beforeEach(() => {
-        ['JF_ARTIFACTORY_1', 'JF_ARTIFACTORY_2', 'ARTIFACTORY_JF_1', 'JF_ENV_1', 'JF_ENV_2', 'ENV_JF_1', 'JF_ENV_LOCAL'].forEach((envKey) => {
-            delete process.env[envKey];
-        });
+const DEFAULT_CLI_URL: string = 'https://releases.jfrog.io/artifactory/jfrog-cli/';
+const CUSTOM_CLI_URL: string = 'http://127.0.0.1:8081/artifactory/jfrog-cli-remote/';
+// Config in JFrog CLI 1.46.3 and below
+const V1_CONFIG: string = `eyJ2ZXJzaW9uIjoxLCJhcnRpZmFjdG9yeVVybCI6Imh0dHA6Ly8xMjcuMC4wLjE6ODA4MS9hcnRpZmFjdG9yeS8iLCJ1c2VyIjoiYWRtaW4iLCJwYXNzd2
+    9yZCI6InBhc3N3b3JkIiwidG9rZW5SZWZyZXNoSW50ZXJ2YWwiOjYwLCJzZXJ2ZXJJZCI6ImxvY2FsIn0=`;
+// Config in JFrog CLI 1.46.4 and above
+const V2_CONFIG: string = `eyJ2ZXJzaW9uIjoyLCJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvIiwiYXJ0aWZhY3RvcnlVcmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvYXJ0aW
+    ZhY3RvcnkvIiwiZGlzdHJpYnV0aW9uVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL2Rpc3RyaWJ1dGlvbi8iLCJ4cmF5VXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL3hyYXkvIiwibWl
+    zc2lvbkNvbnRyb2xVcmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvbWMvIiwicGlwZWxpbmVzVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL3BpcGVsaW5lcy8iLCJ1c2VyIjoiYWRtaW4i
+    LCJwYXNzd29yZCI6InBhc3N3b3JkIiwidG9rZW5SZWZyZXNoSW50ZXJ2YWwiOjYwLCJzZXJ2ZXJJZCI6ImxvY2FsIn0=`;
+const V2_CONFIG_TOKEN: string = `eyJ2ZXJzaW9uIjoyLCJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvIiwiYXJ0aWZhY3RvcnlVcmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEv
+    YXJ0aWZhY3RvcnkvIiwiZGlzdHJpYnV0aW9uVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL2Rpc3RyaWJ1dGlvbi8iLCJ4cmF5VXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL3hyYXkvI
+    iwibWlzc2lvbkNvbnRyb2xVcmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvbWMvIiwicGlwZWxpbmVzVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL3BpcGVsaW5lcy8iLCJhY2Nlc3NUb2
+    tlbiI6ImV5SjJaWElpT2lJeUlpd2lkSGx3SWpvaVNsZFVJaXdpWVd4bklqb2lVbE15TlRZaUxDSnJhV1FpT2lJM1prNXJkWFJ6VXpkdVgwaGlZVE5FZDJGUlNUWk1hVE4zY2s5clZGUkZOMFp
+    GYURWSlJFaEZOelYzSW4wLmV5SmxlSFFpT2lKN1hDSnlaWFp2WTJGaWJHVmNJanBjSW5SeWRXVmNJbjBpTENKemRXSWlPaUpxWm1GalFEQXhabk56YUc0eVkySnJNM0o1TVRFeE1IWmtaR1F4
+    ZW5vMVhDOTFjMlZ5YzF3dllXUnRhVzRpTENKelkzQWlPaUpoY0hCc2FXVmtMWEJsY20xcGMzTnBiMjV6WEM5aFpHMXBiaUlzSW1GMVpDSTZJaXBBS2lJc0ltbHpjeUk2SW1wbVptVkFNREF3S
+    Wl3aVpYaHdJam94Tmpnd09UWTJNRGt4TENKcFlYUWlPakUyTkRrME16QXdPVEVzSW1wMGFTSTZJakJqTWpRMU9UTmxMVGxrWWpVdE5EWXhZeTA1WW1JeUxXTm1ZalV3WldJM1kyRmlaaUo5Ll
+    ZxNG15Q3dLaXVVUG9TMjFNZWxSbXJKMm9qZVlWQVFTU2F3NVF5OUxtcjFMek4wdmxGOG5iVmxYX1VYMkV4OGdGS0VvRndlM2RCMDRvT1A0OVlZQldQWjAweFlwZFFXenRaSENMejZHOUJoZ1p
+    rV29QdHE3MjJ2b01ZOTA0Rk8xcHQ2RzllZEJNQ19odFJNRVMyaGNsQWR3dlVJLW5FN3BrQWE1aFVOZFQxNEU3b1Jna1M0dTM5anU2X1poZ2NWbGhWUDZ5ME5CQlRScjF2dUlkaWlpYmtnYTdD
+    bU5NZldvOVRHS2ZPVU5TNklQbW81MjhfSkRHdVVyZWFjSllsbnV4cDQ5ZGRnZ2NVczR5Zk43eUxHaHNGSUxPei1HaHQxbXFrUWlEb2laeEJMdWlYeGEzdUdraF9CT3ZreGJMT2RNSFRLZjVkd
+    zNsQzdqSXkzSmdudC1WQSIsInNlcnZlcklkIjoibG9jYWwifQ==`;
+
+beforeEach(() => {
+    ['JF_ARTIFACTORY_1', 'JF_ARTIFACTORY_2', 'ARTIFACTORY_JF_1', 'JF_ENV_1', 'JF_ENV_2', 'ENV_JF_1', 'JF_ENV_LOCAL'].forEach((envKey) => {
+        delete process.env[envKey];
     });
+});
 
-    test('Get server tokens', async () => {
-        let serverTokens: Set<string> = Utils.getServerTokens();
-        expect(serverTokens.size).toBe(0);
+test('Get server tokens', async () => {
+    let serverTokens: Set<string> = Utils.getServerTokens();
+    expect(serverTokens.size).toBe(0);
 
-        process.env['ENV_JF_1'] = 'ILLEGAL_SERVER_TOKEN';
-        serverTokens = Utils.getServerTokens();
-        expect(serverTokens.size).toBe(0);
+    process.env['ENV_JF_1'] = 'ILLEGAL_SERVER_TOKEN';
+    serverTokens = Utils.getServerTokens();
+    expect(serverTokens.size).toBe(0);
 
-        process.env['JF_ENV_1'] = 'DUMMY_SERVER_TOKEN_1';
-        serverTokens = Utils.getServerTokens();
-        expect(serverTokens).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1']));
+    process.env['JF_ENV_1'] = 'DUMMY_SERVER_TOKEN_1';
+    serverTokens = Utils.getServerTokens();
+    expect(serverTokens).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1']));
 
-        process.env['JF_ENV_2'] = 'DUMMY_SERVER_TOKEN_2';
-        serverTokens = Utils.getServerTokens();
-        expect(serverTokens).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2']));
+    process.env['JF_ENV_2'] = 'DUMMY_SERVER_TOKEN_2';
+    serverTokens = Utils.getServerTokens();
+    expect(serverTokens).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2']));
+});
+
+test('Get legacy server tokens', async () => {
+    process.env['ARTIFACTORY_JF_1'] = 'ILLEGAL_SERVER_TOKEN';
+    expect(Utils.getServerTokens().size).toBe(0);
+
+    process.env['JF_ARTIFACTORY_1'] = 'DUMMY_SERVER_TOKEN_1';
+    expect(Utils.getServerTokens()).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1']));
+
+    process.env['JF_ARTIFACTORY_2'] = 'DUMMY_SERVER_TOKEN_2';
+    expect(Utils.getServerTokens()).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2']));
+
+    process.env['JF_ENV_1'] = 'DUMMY_SERVER_TOKEN_1';
+    process.env['JF_ENV_2'] = 'DUMMY_SERVER_TOKEN_3';
+    expect(Utils.getServerTokens()).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2', 'DUMMY_SERVER_TOKEN_3']));
+});
+
+describe('JFrog CLI V1 URL Tests', () => {
+    const myOs: jest.Mocked<typeof os> = os as any;
+    let cases: string[][] = [
+        ['win32' as NodeJS.Platform, 'amd64', 'jfrog.exe', 'v1/1.2.3/jfrog-cli-windows-amd64/jfrog.exe'],
+        ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'v1/1.2.3/jfrog-cli-mac-386/jfrog'],
+        ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'v1/1.2.3/jfrog-cli-linux-amd64/jfrog'],
+        ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'v1/1.2.3/jfrog-cli-linux-arm64/jfrog'],
+        ['linux' as NodeJS.Platform, '386', 'jfrog', 'v1/1.2.3/jfrog-cli-linux-386/jfrog'],
+        ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'v1/1.2.3/jfrog-cli-linux-arm/jfrog'],
+    ];
+
+    test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
+        myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
+        myOs.arch.mockImplementation(() => arch);
+        let cliUrl: string = Utils.getCliUrl('1', '1.2.3', fileName, Utils.DEFAULT_DOWNLOAD_DETAILS);
+        expect(cliUrl).toBe(DEFAULT_CLI_URL + expectedUrl);
+
+        process.env.JF_ENV_LOCAL = V1_CONFIG;
+        cliUrl = Utils.getCliUrl('1', '1.2.3', fileName, Utils.extractDownloadDetails('jfrog-cli-remote'));
+        expect(cliUrl).toBe(CUSTOM_CLI_URL + expectedUrl);
     });
+});
 
-    test('Get legacy server tokens', async () => {
-        process.env['ARTIFACTORY_JF_1'] = 'ILLEGAL_SERVER_TOKEN';
-        expect(Utils.getServerTokens().size).toBe(0);
+describe('JFrog CLI V2 URL Tests', () => {
+    const myOs: jest.Mocked<typeof os> = os as any;
+    let cases: string[][] = [
+        ['win32' as NodeJS.Platform, 'amd64', 'jfrog.exe', 'v2/2.3.4/jfrog-cli-windows-amd64/jfrog.exe'],
+        ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'v2/2.3.4/jfrog-cli-mac-386/jfrog'],
+        ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'v2/2.3.4/jfrog-cli-linux-amd64/jfrog'],
+        ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'v2/2.3.4/jfrog-cli-linux-arm64/jfrog'],
+        ['linux' as NodeJS.Platform, '386', 'jfrog', 'v2/2.3.4/jfrog-cli-linux-386/jfrog'],
+        ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'v2/2.3.4/jfrog-cli-linux-arm/jfrog'],
+    ];
 
-        process.env['JF_ARTIFACTORY_1'] = 'DUMMY_SERVER_TOKEN_1';
-        expect(Utils.getServerTokens()).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1']));
+    test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
+        myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
+        myOs.arch.mockImplementation(() => arch);
 
-        process.env['JF_ARTIFACTORY_2'] = 'DUMMY_SERVER_TOKEN_2';
-        expect(Utils.getServerTokens()).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2']));
+        let cliUrl: string = Utils.getCliUrl('2', '2.3.4', fileName, Utils.extractDownloadDetails(''));
+        expect(cliUrl).toBe(DEFAULT_CLI_URL + expectedUrl);
 
-        process.env['JF_ENV_1'] = 'DUMMY_SERVER_TOKEN_1';
-        process.env['JF_ENV_2'] = 'DUMMY_SERVER_TOKEN_3';
-        expect(Utils.getServerTokens()).toStrictEqual(new Set(['DUMMY_SERVER_TOKEN_1', 'DUMMY_SERVER_TOKEN_2', 'DUMMY_SERVER_TOKEN_3']));
+        process.env.JF_ENV_LOCAL = V2_CONFIG;
+        cliUrl = Utils.getCliUrl('2', '2.3.4', fileName, Utils.extractDownloadDetails('jfrog-cli-remote'));
+        expect(cliUrl).toBe(CUSTOM_CLI_URL + expectedUrl);
     });
+});
 
-    describe('JFrog CLI V1 URL Tests', () => {
-        const myOs: jest.Mocked<typeof os> = os as any;
-        let cases: string[][] = [
-            [
-                'win32' as NodeJS.Platform,
-                'amd64',
-                'jfrog.exe',
-                'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-windows-amd64/jfrog.exe',
-            ],
-            ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-mac-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-amd64/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm64/jfrog'],
-            ['linux' as NodeJS.Platform, '386', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v1/1.2.3/jfrog-cli-linux-arm/jfrog'],
-        ];
+test('Extract download details Tests', () => {
+    for (let config of [V1_CONFIG, V2_CONFIG]) {
+        process.env.JF_ENV_LOCAL = config;
+        let downloadDetails: DownloadDetails = Utils.extractDownloadDetails('jfrog-cli-remote');
+        expect(downloadDetails.artifactoryUrl).toBe('http://127.0.0.1:8081/artifactory');
+        expect(downloadDetails.repository).toBe('jfrog-cli-remote');
+        expect(downloadDetails.auth).toBe('Basic YWRtaW46cGFzc3dvcmQ=');
+    }
 
-        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
-            myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
-            myOs.arch.mockImplementation(() => arch);
-            let cliUrl: string = Utils.getCliUrl('1', '1.2.3', fileName);
-            expect(cliUrl).toBe(expectedUrl);
-        });
-    });
+    process.env.JF_ENV_LOCAL = V2_CONFIG_TOKEN;
+    let downloadDetails: DownloadDetails = Utils.extractDownloadDetails('jfrog-cli-remote');
+    expect(downloadDetails.artifactoryUrl).toBe('http://127.0.0.1:8081/artifactory');
+    expect(downloadDetails.repository).toBe('jfrog-cli-remote');
+    expect(downloadDetails.auth).toBe(`Bearer ZXlKMlpYSWlPaUl5SWl3aWRIbHdJam9pU2xkVUlpd2lZV3huSWpvaVVsTXlOVFlpTENKcmFXUWlPaUkzWms1cmRYUnpVemR1WDB\
+oaVlUTkVkMkZSU1RaTWFUTjNjazlyVkZSRk4wWkZhRFZKUkVoRk56VjNJbjAuZXlKbGVIUWlPaUo3WENKeVpYWnZZMkZpYkdWY0lqcGNJblJ5ZFdWY0luMGlMQ0p6ZFdJaU9pSnFabUZqUURBeFpu\
+TnphRzR5WTJKck0zSjVNVEV4TUhaa1pHUXhlbm8xWEM5MWMyVnljMXd2WVdSdGFXNGlMQ0p6WTNBaU9pSmhjSEJzYVdWa0xYQmxjbTFwYzNOcGIyNXpYQzloWkcxcGJpSXNJbUYxWkNJNklpcEFLa\
+UlzSW1semN5STZJbXBtWm1WQU1EQXdJaXdpWlhod0lqb3hOamd3T1RZMk1Ea3hMQ0pwWVhRaU9qRTJORGswTXpBd09URXNJbXAwYVNJNklqQmpNalExT1RObExUbGtZalV0TkRZeFl5MDVZbUl5TF\
+dObVlqVXdaV0kzWTJGaVppSjkuVnE0bXlDd0tpdVVQb1MyMU1lbFJtckoyb2plWVZBUVNTYXc1UXk5TG1yMUx6TjB2bEY4bmJWbFhfVVgyRXg4Z0ZLRW9Gd2UzZEIwNG9PUDQ5WVlCV1BaMDB4WXB\
+kUVd6dFpIQ0x6Nkc5QmhnWmtXb1B0cTcyMnZvTVk5MDRGTzFwdDZHOWVkQk1DX2h0Uk1FUzJoY2xBZHd2VUktbkU3cGtBYTVoVU5kVDE0RTdvUmdrUzR1MzlqdTZfWmhnY1ZsaFZQNnkwTkJCVFJy\
+MXZ1SWRpaWlia2dhN0NtTk1mV285VEdLZk9VTlM2SVBtbzUyOF9KREd1VXJlYWNKWWxudXhwNDlkZGdnY1VzNHlmTjd5TEdoc0ZJTE96LUdodDFtcWtRaURvaVp4Qkx1aVh4YTN1R2toX0JPdmt4Y\
+kxPZE1IVEtmNWR3M2xDN2pJeTNKZ250LVZB`);
+});
 
-    describe('JFrog CLI V2 URL Tests', () => {
-        const myOs: jest.Mocked<typeof os> = os as any;
-        let cases: string[][] = [
-            [
-                'win32' as NodeJS.Platform,
-                'amd64',
-                'jfrog.exe',
-                'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-windows-amd64/jfrog.exe',
-            ],
-            ['darwin' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-mac-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'amd64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-amd64/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm64', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm64/jfrog'],
-            ['linux' as NodeJS.Platform, '386', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-386/jfrog'],
-            ['linux' as NodeJS.Platform, 'arm', 'jfrog', 'https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.3.4/jfrog-cli-linux-arm/jfrog'],
-        ];
-
-        test.each(cases)('CLI Url for %s-%s', (platform, arch, fileName, expectedUrl) => {
-            myOs.platform.mockImplementation(() => <NodeJS.Platform>platform);
-            myOs.arch.mockImplementation(() => arch);
-            let cliUrl: string = Utils.getCliUrl('2', '2.3.4', fileName);
-            expect(cliUrl).toBe(expectedUrl);
-        });
-    });
-
-    test('User agent', () => {
-        let userAgent: string = Utils.USER_AGENT;
-        let split: string[] = userAgent.split('/');
-        expect(split).toHaveLength(2);
-        expect(split[0]).toBe('setup-jfrog-cli-github-action');
-        expect(split[1]).toMatch(/\d*.\d*.\d*/);
-    });
+test('User agent', () => {
+    let userAgent: string = Utils.USER_AGENT;
+    let split: string[] = userAgent.split('/');
+    expect(split).toHaveLength(2);
+    expect(split[0]).toBe('setup-jfrog-cli-github-action');
+    expect(split[1]).toMatch(/\d*.\d*.\d*/);
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Resolves #70.
Usage:

1. Create `jfrog-cli-remote` repository in Artifactory. This repository should point to https://releases.jfrog.io/artifactory/jfrog-cli
2. Set the download-repository input:
```yml
- uses: jfrog/setup-jfrog-cli@v2
  with:
    download-repository: jfrog-cli-remote
```

Notice - In the JFrog Azure DevOps extension it is pointing to https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/ and I thought it would be wiser and more flexible with future and past major versions to use https://releases.jfrog.io/artifactory/jfrog-cli.