### PR TITLE
Improve remote repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It is also possible to set the latest JFrog CLI version by adding the *version* 
 | Important: Only JFrog CLI versions 1.29.0 or above are supported. |
 | --- |
 
-## Downloading JFrog CLI from JFrog Artifactory
+## Downloading JFrog CLI from Artifactory
 If your agent has no Internet access, you can configure the workflow to download JFrog CLI from a [remote repository](https://www.jfrog.com/confluence/display/JFROG/Remote+Repositories) in your JFrog Artifactory, which is configured to proxy the official download URL.
 
 Here's how you do this:
@@ -133,7 +133,7 @@ Here's how you do this:
         download-repository: jfrog-cli-remote
     ```
 
-* See instructions for configuring the _JF_ENV_1_ secret under [Storing JFrog Connection Details as Secrets](#storing-jfrog-connection-details-as-secrets).
+* See instructions for configuring the _JF_SECRET_ENV_1_ secret under [Storing JFrog Connection Details as Secrets](#storing-jfrog-connection-details-as-secrets).
 
 ## Example projects
 To help you get started, you can use [these](https://github.com/jfrog/project-examples/tree/master/github-action-examples) sample projects on GitHub.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ curl -fL https://getcli.jfrog.io?setup | sh
 powershell "Start-Process -Wait -Verb RunAs powershell '-NoProfile iwr https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/[RELEASE]/jfrog-cli-windows-amd64/jf.exe -OutFile $env:SYSTEMROOT\system32\jf.exe'" ; jf setup
 ```
 
-## Storing JFrog connection details as secrets
+## Storing JFrog Connection Details as Secrets
 ### General
 The connection details of the JFrog platform used by JFrog CLI can be stored as secrets.
 
@@ -117,15 +117,23 @@ It is also possible to set the latest JFrog CLI version by adding the *version* 
 | Important: Only JFrog CLI versions 1.29.0 or above are supported. |
 | --- |
 
-## Downloading JFrog CLI From JFrog Artifactory
-If your agent has no internet access, you can configure the workflow to download JFrog CLI from a JFrog Artifactory instance, which is configured to proxy the download repository:
+## Downloading JFrog CLI from JFrog Artifactory
+If your agent has no Internet access, you can configure the workflow to download JFrog CLI from a [remote repository](https://www.jfrog.com/confluence/display/JFROG/Remote+Repositories) in your JFrog Artifactory, which is configured to proxy the official download URL.
+
+Here's how you do this:
+
 1. Create a remote repository in Artifactory. Name the repository jfrog-cli-remote and set its URL to https://releases.jfrog.io/artifactory/jfrog-cli/
 2. Set *download-repository* input to jfrog-cli-remote:
     ```yml
     - uses: jfrog/setup-jfrog-cli@v2
+      env:
+        # The JFrog CLI will be downloaded from the configured Artifactory server in JF_ENV_1
+        JF_ENV_1: ${{ secrets.JF_SECRET_ENV_1 }}
       with:
         download-repository: jfrog-cli-remote
     ```
+
+* See instructions for configuring the _JF_ENV_1_ secret under [Storing JFrog Connection Details as Secrets](#storing-jfrog-connection-details-as-secrets).
 
 ## Example projects
 To help you get started, you can use [these](https://github.com/jfrog/project-examples/tree/master/github-action-examples) sample projects on GitHub.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -227,7 +227,7 @@ class Utils {
             }
             return results;
         }
-        throw new Error(`'download-repository' input provided, but no Artifactory server found. Hint - make sure an environment variable with the JF_EN_ prefix is configured.`);
+        throw new Error(`'download-repository' input provided, but no Artifactory server found. Hint - make sure an environment variable with the JF_ENV_ prefix is configured.`);
     }
     /**
      * Return true if should use 'jfrog rt c' instead of 'jfrog c'.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,7 +238,7 @@ export class Utils {
             return results;
         }
         throw new Error(
-            `'download-repository' input provided, but no Artifactory server found. Hint - make sure an environment variable with the JF_EN_ prefix is configured.`
+            `'download-repository' input provided, but no Artifactory server found. Hint - make sure an environment variable with the JF_ENV_ prefix is configured.`
         );
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

* Improve the instructions for downloading JFrog CLI from a remote repository.
* Fix typo in code (JF_EN -> JF_ENV)