### PR TITLE
Fix authentication flows

### DIFF
--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -54,7 +54,7 @@ jobs:
                 "name": "oidc-test-identity-mapping",
                 "priority": "1",
                 "claims": {
-                  "sub": "repo:jfrog/setup-jfrog-cli:ref:refs/heads/main",
+                  "sub": "repo:${{ github.repository_owner }}/setup-jfrog-cli:ref:${{ github.ref }}",
                   "iss": "https://token.actions.githubusercontent.com"
                 },
                 "token_spec": {
@@ -72,7 +72,7 @@ jobs:
 
       - name: Test JFrog CLI
         run: |
-          jf rt ping
+          jf rt s "some-repo/"
 
       # Removing the OIDC integration will remove the Identity Mapping as well
       - name: Delete OIDC integration

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -79,16 +79,17 @@ class Utils {
      * @returns true if OpenID Connect authentication should be used
      */
     static shouldUseOpenIDConnect(jfrogCredentials) {
+        if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+            // To enable OpenIDConnect authentication, users must configure the 'id-token: write' permission, which sets the ACTIONS_ID_TOKEN_REQUEST_URL environment variable.
+            // If this variable is empty, it indicates that OIDC should not be utilized.
+            return false;
+        }
         if (!jfrogCredentials.jfrogUrl) {
             // If no JFrog URL is specified, we can't use OpenID Connect
             return false;
         }
         if (jfrogCredentials.password || jfrogCredentials.accessToken) {
             // If credentials are specified - use them instead
-            return false;
-        }
-        if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
-            // Only if the user added the 'id-token: write' permission, this environment variable was set
             return false;
         }
         return true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,7 +51,7 @@ class Utils {
     static getJfrogCredentials() {
         return __awaiter(this, void 0, void 0, function* () {
             let jfrogCredentials = this.collectJfrogCredentialsFromEnvVars();
-            if (!jfrogCredentials.jfrogUrl || jfrogCredentials.password || jfrogCredentials.accessToken || !process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+            if (!this.shouldUseOpenIDConnect(jfrogCredentials)) {
                 // Use JF_ENV or the credentials found in the environment variables
                 return jfrogCredentials;
             }
@@ -72,6 +72,26 @@ class Utils {
                 throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);
             }
         });
+    }
+    /**
+     * Returns true if OpenID Connect authentication should be used.
+     * @param jfrogCredentials - Credentials retrieved from the environment variables
+     * @returns true if OpenID Connect authentication should be used
+     */
+    static shouldUseOpenIDConnect(jfrogCredentials) {
+        if (!jfrogCredentials.jfrogUrl) {
+            // If no JFrog URL is specified, we can't use OpenID Connect
+            return false;
+        }
+        if (jfrogCredentials.password || jfrogCredentials.accessToken) {
+            // If credentials are specified - use them instead
+            return false;
+        }
+        if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+            // Only if the user added the 'id-token: write' permission, this environment variable was set
+            return false;
+        }
+        return true;
     }
     /**
      * Gathers JFrog's credentials from environment variables and delivers them in a JfrogCredentials structure

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,14 +51,11 @@ class Utils {
     static getJfrogCredentials() {
         return __awaiter(this, void 0, void 0, function* () {
             let jfrogCredentials = this.collectJfrogCredentialsFromEnvVars();
-            if (!jfrogCredentials.jfrogUrl) {
+            if (!jfrogCredentials.jfrogUrl || jfrogCredentials.password || jfrogCredentials.accessToken || !process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+                // Use JF_ENV or the credentials found in the environment variables
                 return jfrogCredentials;
             }
-            // If the required credentials, such as the access token or a combination of username and password, are available, the process terminates without triggering the OIDC flow
-            if (jfrogCredentials.accessToken || (jfrogCredentials.username && jfrogCredentials.password)) {
-                return jfrogCredentials;
-            }
-            core.info("JF_ACCESS_TOKEN and JF_USER + JF_PASSWORD weren't found. Getting access token using OpenID Connect");
+            core.info('The JFrog platform credentials were not configured. Obtaining an access token through OpenID Connect.');
             const audience = core.getInput(Utils.OIDC_AUDIENCE_ARG);
             let jsonWebToken;
             try {
@@ -79,23 +76,20 @@ class Utils {
     /**
      * Gathers JFrog's credentials from environment variables and delivers them in a JfrogCredentials structure
      * @returns JfrogCredentials struct with all credentials found in environment variables
+     * @throws Error if a password provided without a username
      */
     static collectJfrogCredentialsFromEnvVars() {
-        let jfrogCredentials = {};
-        core.debug('Searching for JF_URL');
-        if (process.env.JF_URL) {
-            core.debug('JF_URL found');
-            jfrogCredentials.jfrogUrl = process.env.JF_URL;
+        let jfrogCredentials = {
+            jfrogUrl: process.env.JF_URL,
+            accessToken: process.env.JF_ACCESS_TOKEN,
+            username: process.env.JF_USER,
+            password: process.env.JF_PASSWORD,
+        };
+        if (jfrogCredentials.password && !jfrogCredentials.username) {
+            throw new Error('JF_PASSWORD is configured, but the JF_USER environment variable was not set.');
         }
-        core.debug('Searching for JF_ACCESS_TOKEN, JF_USER and JF_PASSWORD');
-        if (process.env.JF_ACCESS_TOKEN) {
-            core.debug('JF_ACCESS_TOKEN found');
-            jfrogCredentials.accessToken = process.env.JF_ACCESS_TOKEN;
-        }
-        if (process.env.JF_USER && process.env.JF_PASSWORD) {
-            core.debug('JF_USER and JF_PASSWORD found');
-            jfrogCredentials.username = process.env.JF_USER;
-            jfrogCredentials.password = process.env.JF_PASSWORD;
+        if (jfrogCredentials.username && !jfrogCredentials.accessToken && !jfrogCredentials.password) {
+            throw new Error('JF_USER is configured, but the JF_PASSWORD or JF_ACCESS_TOKEN environment variables were not set.');
         }
         return jfrogCredentials;
     }
@@ -125,6 +119,9 @@ class Utils {
             const responseString = yield response.readBody();
             const responseJson = JSON.parse(responseString);
             jfrogCredentials.accessToken = responseJson.access_token;
+            if (jfrogCredentials.accessToken) {
+                core.setSecret(jfrogCredentials.accessToken);
+            }
             return jfrogCredentials;
         });
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,16 +78,17 @@ export class Utils {
      * @returns true if OpenID Connect authentication should be used
      */
     private static shouldUseOpenIDConnect(jfrogCredentials: JfrogCredentials): boolean {
+        if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+            // To enable OpenIDConnect authentication, users must configure the 'id-token: write' permission, which sets the ACTIONS_ID_TOKEN_REQUEST_URL environment variable.
+            // If this variable is empty, it indicates that OIDC should not be utilized.
+            return false;
+        }
         if (!jfrogCredentials.jfrogUrl) {
             // If no JFrog URL is specified, we can't use OpenID Connect
             return false;
         }
         if (jfrogCredentials.password || jfrogCredentials.accessToken) {
             // If credentials are specified - use them instead
-            return false;
-        }
-        if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
-            // Only if the user added the 'id-token: write' permission, this environment variable was set
             return false;
         }
         return true;

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -82,7 +82,7 @@ describe('Collect credentials from environment variables test', () => {
     ];
 
     test.each(cases)(
-        'Checking Jfrog credentials struct for url: %s, access token %s, username: %s, password: %s',
+        'Checking JFrog credentials struct for url: %s, access token %s, username: %s, password: %s',
         (jfrogUrl, accessToken, username, password) => {
             process.env['JF_URL'] = jfrogUrl;
             process.env['JF_ACCESS_TOKEN'] = accessToken;
@@ -93,53 +93,43 @@ describe('Collect credentials from environment variables test', () => {
             if (jfrogUrl) {
                 expect(jfrogCredentials.jfrogUrl).toEqual(jfrogUrl);
             } else {
-                expect(jfrogCredentials.jfrogUrl).toBeUndefined();
+                expect(jfrogCredentials.jfrogUrl).toBeFalsy();
             }
 
             if (accessToken) {
                 expect(jfrogCredentials.accessToken).toEqual(accessToken);
             } else {
-                expect(jfrogCredentials.accessToken).toBeUndefined();
+                expect(jfrogCredentials.accessToken).toBeFalsy();
             }
 
             if (username) {
                 expect(jfrogCredentials.username).toEqual(username);
             } else {
-                expect(jfrogCredentials.username).toBeUndefined();
+                expect(jfrogCredentials.username).toBeFalsy();
             }
 
             if (password) {
                 expect(jfrogCredentials.password).toEqual(password);
             } else {
-                expect(jfrogCredentials.password).toBeUndefined();
+                expect(jfrogCredentials.password).toBeFalsy();
             }
         },
     );
 });
 
-test('Collect JFrog Credentials from env vars', async () => {
-    process.env['JF_URL'] = '';
-    let jfrogCredentials: JfrogCredentials = Utils.collectJfrogCredentialsFromEnvVars();
-    expect(jfrogCredentials.jfrogUrl).toBeUndefined();
-    expect(jfrogCredentials.username).toBeUndefined();
-    expect(jfrogCredentials.password).toBeUndefined();
-    expect(jfrogCredentials.accessToken).toBeUndefined();
+describe('Collect JFrog Credentials from env vars exceptions', () => {
+    let cases: string[][] = [
+        // [JF_USER, JF_PASSWORD, EXCEPTION]
+        ['', 'password', 'JF_PASSWORD is configured, but the JF_USER environment variable was not set.'],
+        ['user', '', 'JF_USER is configured, but the JF_PASSWORD or JF_ACCESS_TOKEN environment variables were not set.'],
+    ];
 
-    process.env['JF_URL'] = 'https://my-server.io';
-    process.env['JF_ACCESS_TOKEN'] = 'my-access-token';
-    jfrogCredentials = Utils.collectJfrogCredentialsFromEnvVars();
-    expect(jfrogCredentials.jfrogUrl).toEqual('https://my-server.io');
-    expect(jfrogCredentials.username).toBeUndefined();
-    expect(jfrogCredentials.password).toBeUndefined();
-    expect(jfrogCredentials.accessToken).toEqual('my-access-token');
-
-    process.env['JF_USER'] = 'user';
-    process.env['JF_PASSWORD'] = 'password';
-    jfrogCredentials = Utils.collectJfrogCredentialsFromEnvVars();
-    expect(jfrogCredentials.jfrogUrl).toEqual('https://my-server.io');
-    expect(jfrogCredentials.username).toEqual('user');
-    expect(jfrogCredentials.password).toEqual('password');
-    expect(jfrogCredentials.accessToken).toEqual('my-access-token');
+    test.each(cases)('Checking JFrog credentials struct for username: %s, password: %s', (username, password, exception) => {
+        process.env['JF_ACCESS_TOKEN'] = '';
+        process.env['JF_USER'] = username;
+        process.env['JF_PASSWORD'] = password;
+        expect(() => Utils.collectJfrogCredentialsFromEnvVars()).toThrow(new Error(exception));
+    });
 });
 
 test('Get separate env config', async () => {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fix #121 

* Fix anonymous access
* Fix authentication with username + access token
* When there are no credentials provided, allow at least downloading the CLI
* Fix integration test to run search command instead of ping, because ping is allowed without credentials
* Make the integration test run on forks, if credentials provided