### PR TITLE
Force the cleanup script to use the tool cache

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -38,7 +38,9 @@ function cleanup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.startGroup('Cleanup JFrog CLI servers configuration');
-            yield utils_1.Utils.getAndAddCliToPath({});
+            if (!(yield utils_1.Utils.addCachedCliToPath())) {
+                return;
+            }
             yield utils_1.Utils.removeJFrogServers();
         }
         catch (error) {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -38,7 +38,7 @@ function cleanup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.startGroup('Cleanup JFrog CLI servers configuration');
-            if (!(yield utils_1.Utils.addCachedCliToPath())) {
+            if (!utils_1.Utils.addCachedCliToPath()) {
                 return;
             }
             yield utils_1.Utils.removeJFrogServers();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -178,19 +178,17 @@ class Utils {
      * Fetch the JFrog CLI path from the tool cache and append it to the PATH environment variable. Employ this approach during the cleanup phase.
      */
     static addCachedCliToPath() {
-        return __awaiter(this, void 0, void 0, function* () {
-            let version = core.getInput(Utils.CLI_VERSION_ARG);
-            if (version === Utils.LATEST_CLI_VERSION) {
-                version = Utils.LATEST_RELEASE_VERSION;
-            }
-            let jfrogCliPath = toolCache.find(Utils.getJfExecutableName(), version);
-            if (!jfrogCliPath) {
-                core.warning(`Could not find JFrog CLI version '${version}' in tool cache`);
-                return false;
-            }
-            core.addPath(jfrogCliPath);
-            return true;
-        });
+        let version = core.getInput(Utils.CLI_VERSION_ARG);
+        if (version === Utils.LATEST_CLI_VERSION) {
+            version = Utils.LATEST_RELEASE_VERSION;
+        }
+        let jfrogCliPath = toolCache.find(Utils.getJfExecutableName(), version);
+        if (!jfrogCliPath) {
+            core.warning(`Could not find JFrog CLI version '${version}' in tool cache`);
+            return false;
+        }
+        core.addPath(jfrogCliPath);
+        return true;
     }
     /**
      * Try to load the JFrog CLI executables from cache.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,12 +35,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.Utils = void 0;
 const core = __importStar(require("@actions/core"));
 const exec_1 = require("@actions/exec");
+const http_client_1 = require("@actions/http-client");
 const toolCache = __importStar(require("@actions/tool-cache"));
 const fs_1 = require("fs");
 const os_1 = require("os");
 const path_1 = require("path");
 const semver_1 = require("semver");
-const http_client_1 = require("@actions/http-client");
 class Utils {
     /**
      * Retrieves server credentials for accessing JFrog's server
@@ -151,7 +151,7 @@ class Utils {
             let version = core.getInput(Utils.CLI_VERSION_ARG);
             let cliRemote = core.getInput(Utils.CLI_REMOTE_ARG);
             let major = version.split('.')[0];
-            if (version === this.LATEST_CLI_VERSION) {
+            if (version === Utils.LATEST_CLI_VERSION) {
                 version = Utils.LATEST_RELEASE_VERSION;
                 major = '2';
             }
@@ -172,6 +172,24 @@ class Utils {
             // Cache 'jf' and 'jfrog' executables
             yield this.cacheAndAddPath(downloadDir, version, jfFileName);
             yield this.cacheAndAddPath(downloadDir, version, jfrogFileName);
+        });
+    }
+    /**
+     * Fetch the JFrog CLI path from the tool cache and append it to the PATH environment variable. Employ this approach during the cleanup phase.
+     */
+    static addCachedCliToPath() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let version = core.getInput(Utils.CLI_VERSION_ARG);
+            if (version === Utils.LATEST_CLI_VERSION) {
+                version = Utils.LATEST_RELEASE_VERSION;
+            }
+            let jfrogCliPath = toolCache.find(Utils.getJfExecutableName(), version);
+            if (!jfrogCliPath) {
+                core.warning(`Could not find JFrog CLI version '${version}' in tool cache`);
+                return false;
+            }
+            core.addPath(jfrogCliPath);
+            return true;
         });
     }
     /**

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,10 +1,10 @@
 import * as core from '@actions/core';
-import { JfrogCredentials, Utils } from './utils';
+import { Utils } from './utils';
 
 async function cleanup() {
     try {
         core.startGroup('Cleanup JFrog CLI servers configuration');
-        if (!(await Utils.addCachedCliToPath())) {
+        if (!Utils.addCachedCliToPath()) {
             return;
         }
         await Utils.removeJFrogServers();

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -4,7 +4,9 @@ import { JfrogCredentials, Utils } from './utils';
 async function cleanup() {
     try {
         core.startGroup('Cleanup JFrog CLI servers configuration');
-        await Utils.getAndAddCliToPath({} as JfrogCredentials);
+        if (!(await Utils.addCachedCliToPath())) {
+            return;
+        }
         await Utils.removeJFrogServers();
     } catch (error) {
         core.setFailed((<any>error).message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,12 @@
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';
+import { HttpClient, HttpClientResponse } from '@actions/http-client';
 import * as toolCache from '@actions/tool-cache';
 import { chmodSync } from 'fs';
+import { OutgoingHttpHeaders } from 'http';
 import { arch, platform } from 'os';
 import { join } from 'path';
 import { lt } from 'semver';
-import { HttpClient, HttpClientResponse } from '@actions/http-client';
-import { OutgoingHttpHeaders } from 'http';
 
 export class Utils {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -182,7 +182,7 @@ export class Utils {
     /**
      * Fetch the JFrog CLI path from the tool cache and append it to the PATH environment variable. Employ this approach during the cleanup phase.
      */
-    public static async addCachedCliToPath(): Promise<boolean> {
+    public static addCachedCliToPath(): boolean {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
         if (version === Utils.LATEST_CLI_VERSION) {
             version = Utils.LATEST_RELEASE_VERSION;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,7 +154,7 @@ export class Utils {
         let version: string = core.getInput(Utils.CLI_VERSION_ARG);
         let cliRemote: string = core.getInput(Utils.CLI_REMOTE_ARG);
         let major: string = version.split('.')[0];
-        if (version === this.LATEST_CLI_VERSION) {
+        if (version === Utils.LATEST_CLI_VERSION) {
             version = Utils.LATEST_RELEASE_VERSION;
             major = '2';
         } else if (lt(version, this.MIN_CLI_VERSION)) {
@@ -177,6 +177,23 @@ export class Utils {
         // Cache 'jf' and 'jfrog' executables
         await this.cacheAndAddPath(downloadDir, version, jfFileName);
         await this.cacheAndAddPath(downloadDir, version, jfrogFileName);
+    }
+
+    /**
+     * Fetch the JFrog CLI path from the tool cache and append it to the PATH environment variable. Employ this approach during the cleanup phase.
+     */
+    public static async addCachedCliToPath(): Promise<boolean> {
+        let version: string = core.getInput(Utils.CLI_VERSION_ARG);
+        if (version === Utils.LATEST_CLI_VERSION) {
+            version = Utils.LATEST_RELEASE_VERSION;
+        }
+        let jfrogCliPath: string = toolCache.find(Utils.getJfExecutableName(), version);
+        if (!jfrogCliPath) {
+            core.warning(`Could not find JFrog CLI version '${version}' in tool cache`);
+            return false;
+        }
+        core.addPath(jfrogCliPath);
+        return true;
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fix #120 

In the cleanup stage, use JFrog CLI from the cache and avoid downloading it. Before this pull request, we downloaded the JFrog CLI when the version was set to "latest".