### PR TITLE
Bump undici from 5.28.2 to 5.28.3

### DIFF
--- a/node_modules/undici/lib/fetch/index.js
+++ b/node_modules/undici/lib/fetch/index.js
@@ -1203,6 +1203,9 @@ function httpRedirectFetch (fetchParams, response) {
     // https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name
     request.headersList.delete('authorization')
 
+    // https://fetch.spec.whatwg.org/#authentication-entries
+    request.headersList.delete('proxy-authorization', true)
+
     // "Cookie" and "Host" are forbidden request-headers, which undici doesn't implement.
     request.headersList.delete('cookie')
     request.headersList.delete('host')

--- a/node_modules/undici/package.json
+++ b/node_modules/undici/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undici",
-  "version": "5.28.2",
+  "version": "5.28.3",
   "description": "An HTTP/1.1 client, written from scratch for Node.js",
   "homepage": "https://undici.nodejs.org",
   "bugs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4430,9 +4430,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.28.2",
-            "resolved": "https://entplus.jfrog.io/artifactory/api/npm/bapps-npm-virtual/undici/-/undici-5.28.2.tgz",
-            "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+            "version": "5.28.3",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+            "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },
@@ -7391,9 +7391,9 @@
             "dev": true
         },
         "undici": {
-            "version": "5.28.2",
-            "resolved": "https://entplus.jfrog.io/artifactory/api/npm/bapps-npm-virtual/undici/-/undici-5.28.2.tgz",
-            "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+            "version": "5.28.3",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+            "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
             "requires": {
                 "@fastify/busboy": "^2.0.0"
             }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
