### PR TITLE
feat: add `token` to output if available

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
     oidc-audience:
         description: "By default, this is the URL of the GitHub repository owner, such as the organization that owns the repository."
         required: false
+outputs:
+    token:
+        description: ""
 
 runs:
     using: "node20"

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,6 +40,9 @@ function main() {
             core.startGroup('Setup JFrog CLI');
             utils_1.Utils.setCliEnv();
             let jfrogCredentials = yield utils_1.Utils.getJfrogCredentials();
+            if (jfrogCredentials.accessToken != '') {
+                core.setOutput('token', jfrogCredentials.accessToken);
+            }
             yield utils_1.Utils.getAndAddCliToPath(jfrogCredentials);
             yield utils_1.Utils.configJFrogServers(jfrogCredentials);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,9 @@ async function main() {
         core.startGroup('Setup JFrog CLI');
         Utils.setCliEnv();
         let jfrogCredentials: JfrogCredentials = await Utils.getJfrogCredentials();
+        if (jfrogCredentials.accessToken != '') {
+            core.setOutput('token', jfrogCredentials.accessToken);
+        }
         await Utils.getAndAddCliToPath(jfrogCredentials);
         await Utils.configJFrogServers(jfrogCredentials);
     } catch (error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. ~If this feature is not already covered by the tests, I added new tests.~
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
# Description
allows other actions in a workflow to get at the token used to auth the CLI which is especially useful for OIDC auth

## Solved problem
there isn't a way to get the token to use in other applications from the `jf` commands themselves, and the config is encrypted

# Questions
1. what description would be appropriate for the output? i wasn't sure how to word all the cases where a token would/would not be returned.
2. what test can be added for this?
