### PR TITLE
Add starter workflow

### DIFF
--- a/starter-workflows/ci/properties/setup-jfrog-cli.properties.json
+++ b/starter-workflows/ci/properties/setup-jfrog-cli.properties.json
@@ -1,0 +1,25 @@
+{
+    "name": "Setup JFrog CLI",
+    "description": "Set up JFrog CLI in your GitHub Actions workflow.",
+    "iconName": "setup-jfrog-cli",
+    "categories": [
+      "Continuous integration",
+      "Dependency management",
+      "Go",
+      "Artifactory",
+      "C#",
+      "Dockerfile",
+      "Go Module",
+      "Gradle",
+      "Java",
+      "JavaScript",
+      "Maven POM",
+      "npm",
+      "NPM Config",
+      "Pip",
+      "Pip Requirements",
+      "Python",
+      "Yarn"
+    ],
+    "creator": "JFrog"
+  }

--- a/starter-workflows/ci/setup-jfrog-cli.yml
+++ b/starter-workflows/ci/setup-jfrog-cli.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will set up JFrog CLI and publish build info to JFrog Artifactory.
+name: "Setup JFrog CLI"
+on:
+  push:
+    branches: [ $default-branch, $protected-branches ]
+  release:
+    types: [ created ]
+
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          # JFrog Platform URL
+          JF_URL: https://acme.jfrog.io
+
+          # JFrog Platform access token
+          JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
+
+          # Basic authentication credentials
+          # JF_USER: ${{ secrets.JF_USER }}
+          # JF_PASSWORD: ${{ secrets.JF_PASSWORD }}
+
+      - name: Run JFrog CLI
+        run: |
+          # Ping the server
+          jf rt ping
+          # Collect environment variables for the build
+          jf rt bce
+          # Collect VCS details from git and add them to the build
+          jf rt bag
+          # Publish build info
+          jf rt bp


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Add a starter workflow that will ideally represent the actual starter workflow to be included at https://github.com/actions/starter-workflows/tree/main/ci. These files are included in this repository solely for code review purposes.
For simplicity, this workflow demonstrates standard authentication rather than OpenID Connect, which requires additional configuration in the JFrog Platform.
The workflow demonstrates the basic process of creating a Build Info and publishing it to Artifactory upon push or release.

![image](https://github.com/jfrog/setup-jfrog-cli/assets/11367982/c1a7bfd5-c2ab-4939-9ce9-7d77d8310615)
