### PR TITLE
Fix broken URL in OIDC tests

### DIFF
--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc" -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" -d '{
           "name": "${{ env.OIDC_PROVIDER_NAME }}",
-          "issuer_url": "https://token.actions.githubusercontent.com",
+          "issuer_url": "https://token.actions.githubusercontent.com/",
           "provider_type": "GitHub",
           "description": "This is a test configuration created for OIDC-Access integration test" }'
 
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: test -n "${{ steps.setup-jfrog-cli.outputs.oidc-token }}"
 
-      # Removing the OIDC integration will remove the Identity Mapping as well
+      # Removing the OIDC integration will remove the Identity Mapping as well BLABLA
       - name: Delete OIDC integration
         shell: bash
         if: always()

--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc" -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" -d '{
           "name": "${{ env.OIDC_PROVIDER_NAME }}",
-          "issuer_url": "https://token.actions.githubusercontent.com/",
+          "issuer_url": "https://token.actions.githubusercontent.com",
           "provider_type": "GitHub",
           "description": "This is a test configuration created for OIDC-Access integration test" }'
 
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: test -n "${{ steps.setup-jfrog-cli.outputs.oidc-token }}"
 
-      # Removing the OIDC integration will remove the Identity Mapping as well BLABLA
+      # Removing the OIDC integration will remove the Identity Mapping as well
       - name: Delete OIDC integration
         shell: bash
         if: always()

--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc" -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" -d '{
           "name": "${{ env.OIDC_PROVIDER_NAME }}",
-          "issuer_url": "https://token.actions.githubusercontent.com/",
+          "issuer_url": "https://token.actions.githubusercontent.com",
           "provider_type": "GitHub",
           "description": "This is a test configuration created for OIDC-Access integration test" }'
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Fixed a URL in OIDC tests due to failure we experienced in the OIDC tests in Frogbot: https://github.com/jfrog/frogbot/pull/708
It was verified in the second commit that the OIDC tests are failing over the same issue