### PR TITLE
Fix color scheme not supported

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -546,6 +546,7 @@ class Utils {
         if (!platformUrl) {
             return '';
         }
+        platformUrl = platformUrl.replace(/^https:\/\//i, "http://");
         if (!platformUrl.endsWith('/')) {
             platformUrl = platformUrl + '/';
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -465,6 +465,7 @@ class Utils {
                     return;
                 }
                 // Write to GitHub's job summary
+                core.info(markdownContent);
                 core.summary.addRaw(markdownContent, true);
                 yield core.summary.write({ overwrite: true });
                 // Clear files

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -465,7 +465,6 @@ class Utils {
                     return;
                 }
                 // Write to GitHub's job summary
-                core.info(markdownContent);
                 core.summary.addRaw(markdownContent, true);
                 yield core.summary.write({ overwrite: true });
                 // Clear files
@@ -546,7 +545,8 @@ class Utils {
         if (!platformUrl) {
             return '';
         }
-        platformUrl = platformUrl.replace(/^https:\/\//i, "http://");
+        // Change protocol to avoid masking of the URL and breaking it.
+        platformUrl = platformUrl.replace(/^https:\/\//i, 'http://');
         if (!platformUrl.endsWith('/')) {
             platformUrl = platformUrl + '/';
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -521,12 +521,14 @@ class Utils {
         }
         return mainTitle + Utils.getProjectPackagesLink();
     }
+    /**
+     * Check if the color scheme is supported in the GitHub UI.
+     * Currently, GitHub enterprise does not support the color scheme $\textcolor{}.
+     * @returns <boolean> true if the color scheme is supported, false otherwise.
+     */
     static isColorSchemeSupported() {
         let serverUrl = process.env.GITHUB_SERVER_URL || '';
-        let testBoolean = serverUrl.includes('github.com');
-        core.info('Color scheme supported: ' + testBoolean);
-        core.info('server url is : ' + serverUrl);
-        return testBoolean;
+        return serverUrl.includes('github.com');
     }
     /**
      * Gets the project packages link to be displayed in the summary

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -459,7 +459,7 @@ class Utils {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 // Read all sections and construct the final markdown file
-                const markdownContent = yield this.readCLIMarkdownSections();
+                const markdownContent = yield this.readCLIMarkdownSectionsAndWrap();
                 if (markdownContent.length == 0) {
                     core.debug('No job summaries sections found. Workflow summary will not be generated.');
                     return;
@@ -480,7 +480,7 @@ class Utils {
      * This function reads each section file and wraps it with a markdown header
      * @returns <string> the content of the markdown file as string, warped in a collapsable section.
      */
-    static readCLIMarkdownSections() {
+    static readCLIMarkdownSectionsAndWrap() {
         return __awaiter(this, void 0, void 0, function* () {
             const outputDir = Utils.getJobOutputDirectoryPath();
             let markdownContent = '';
@@ -512,8 +512,21 @@ class Utils {
         });
     }
     static getMarkdownHeader() {
-        let mainTitle = `# $\\textcolor{green}{\\textsf{ 🐸 JFrog Job Summary}}$` + '\n\n';
+        let mainTitle;
+        if (Utils.isColorSchemeSupported()) {
+            mainTitle = `# $\\textcolor{green}{\\textsf{ 🐸 JFrog Job Summary}}$` + '\n\n';
+        }
+        else {
+            mainTitle = `# 🐸 JFrog Job Summary` + '\n\n';
+        }
         return mainTitle + Utils.getProjectPackagesLink();
+    }
+    static isColorSchemeSupported() {
+        let serverUrl = process.env.GITHUB_SERVER_URL || '';
+        let testBoolean = serverUrl.includes('github.com');
+        core.info('Color scheme supported: ' + testBoolean);
+        core.info('server url is : ' + serverUrl);
+        return testBoolean;
     }
     /**
      * Gets the project packages link to be displayed in the summary

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -526,6 +526,9 @@ class Utils {
      * Currently, GitHub enterprise does not support the color LaTex scheme $\textcolor{}.
      * This scheme is part of the LaTeX/Mathematics scheme.
      *
+     * Currently, the scheme is not supported by GitHub Enterprise version 3.13,
+     * which is the latest version at the time of writing this comment.
+     *
      * For more info about the scheme see:
      * https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
      *

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -528,7 +528,7 @@ class Utils {
      */
     static isColorSchemeSupported() {
         let serverUrl = process.env.GITHUB_SERVER_URL || '';
-        return serverUrl.includes('github.com');
+        return serverUrl.startsWith('https://github.com');
     }
     /**
      * Gets the project packages link to be displayed in the summary

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -548,8 +548,6 @@ class Utils {
         if (!platformUrl) {
             return '';
         }
-        // Change protocol to avoid masking of the URL and breaking it.
-        platformUrl = platformUrl.replace(/^https:\/\//i, 'http://');
         if (!platformUrl.endsWith('/')) {
             platformUrl = platformUrl + '/';
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -523,7 +523,12 @@ class Utils {
     }
     /**
      * Check if the color scheme is supported in the GitHub UI.
-     * Currently, GitHub enterprise does not support the color scheme $\textcolor{}.
+     * Currently, GitHub enterprise does not support the color LaTex scheme $\textcolor{}.
+     * This scheme is part of the LaTeX/Mathematics scheme.
+     *
+     * For more info about the scheme see:
+     * https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
+     *
      * @returns <boolean> true if the color scheme is supported, false otherwise.
      */
     static isColorSchemeSupported() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -502,7 +502,6 @@ export class Utils {
                 return;
             }
             // Write to GitHub's job summary
-            core.info(markdownContent);
             core.summary.addRaw(markdownContent, true);
             await core.summary.write({ overwrite: true });
             // Clear files
@@ -583,7 +582,8 @@ export class Utils {
         if (!platformUrl) {
             return '';
         }
-        platformUrl = platformUrl.replace(/^https:\/\//i, "http://");
+        // Change protocol to avoid masking of the URL and breaking it.
+        platformUrl = platformUrl.replace(/^https:\/\//i, 'http://');
         if (!platformUrl.endsWith('/')) {
             platformUrl = platformUrl + '/';
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -557,12 +557,14 @@ export class Utils {
         return mainTitle + Utils.getProjectPackagesLink();
     }
 
+    /**
+     * Check if the color scheme is supported in the GitHub UI.
+     * Currently, GitHub enterprise does not support the color scheme $\textcolor{}.
+     * @returns <boolean> true if the color scheme is supported, false otherwise.
+     */
     private static isColorSchemeSupported() {
         let serverUrl: string = process.env.GITHUB_SERVER_URL || '';
-        let testBoolean: boolean = serverUrl.includes('github.com');
-        core.info('Color scheme supported: ' + testBoolean);
-        core.info('server url is : ' + serverUrl);
-        return testBoolean;
+        return serverUrl.includes('github.com');
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -496,7 +496,7 @@ export class Utils {
     public static async generateWorkflowSummaryMarkdown() {
         try {
             // Read all sections and construct the final markdown file
-            const markdownContent: string = await this.readCLIMarkdownSections();
+            const markdownContent: string = await this.readCLIMarkdownSectionsAndWrap();
             if (markdownContent.length == 0) {
                 core.debug('No job summaries sections found. Workflow summary will not be generated.');
                 return;
@@ -516,7 +516,7 @@ export class Utils {
      * This function reads each section file and wraps it with a markdown header
      * @returns <string> the content of the markdown file as string, warped in a collapsable section.
      */
-    private static async readCLIMarkdownSections(): Promise<string> {
+    private static async readCLIMarkdownSectionsAndWrap(): Promise<string> {
         const outputDir: string = Utils.getJobOutputDirectoryPath();
         let markdownContent: string = '';
 
@@ -548,8 +548,21 @@ export class Utils {
     }
 
     private static getMarkdownHeader(): string {
-        let mainTitle: string = `# $\\textcolor{green}{\\textsf{ 🐸 JFrog Job Summary}}$` + '\n\n';
+        let mainTitle: string;
+        if (Utils.isColorSchemeSupported()) {
+            mainTitle = `# $\\textcolor{green}{\\textsf{ 🐸 JFrog Job Summary}}$` + '\n\n';
+        } else {
+            mainTitle = `# 🐸 JFrog Job Summary` + '\n\n';
+        }
         return mainTitle + Utils.getProjectPackagesLink();
+    }
+
+    private static isColorSchemeSupported() {
+        let serverUrl: string = process.env.GITHUB_SERVER_URL || '';
+        let testBoolean: boolean = serverUrl.includes('github.com');
+        core.info('Color scheme supported: ' + testBoolean);
+        core.info('server url is : ' + serverUrl);
+        return testBoolean;
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -562,7 +562,7 @@ export class Utils {
      * Currently, GitHub enterprise does not support the color scheme $\textcolor{}.
      * @returns <boolean> true if the color scheme is supported, false otherwise.
      */
-    private static isColorSchemeSupported() {
+    static isColorSchemeSupported() {
         let serverUrl: string = process.env.GITHUB_SERVER_URL || '';
         return serverUrl.includes('github.com');
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -564,7 +564,7 @@ export class Utils {
      */
     static isColorSchemeSupported() {
         let serverUrl: string = process.env.GITHUB_SERVER_URL || '';
-        return serverUrl.includes('github.com');
+        return serverUrl.startsWith('https://github.com');
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -583,6 +583,7 @@ export class Utils {
         if (!platformUrl) {
             return '';
         }
+        platformUrl = platformUrl.replace(/^https:\/\//i, "http://");
         if (!platformUrl.endsWith('/')) {
             platformUrl = platformUrl + '/';
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -562,6 +562,9 @@ export class Utils {
      * Currently, GitHub enterprise does not support the color LaTex scheme $\textcolor{}.
      * This scheme is part of the LaTeX/Mathematics scheme.
      *
+     * Currently, the scheme is not supported by GitHub Enterprise version 3.13,
+     * which is the latest version at the time of writing this comment.
+     *
      * For more info about the scheme see:
      * https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
      *
@@ -582,8 +585,6 @@ export class Utils {
         if (!platformUrl) {
             return '';
         }
-        // Change protocol to avoid masking of the URL and breaking it.
-        platformUrl = platformUrl.replace(/^https:\/\//i, 'http://');
         if (!platformUrl.endsWith('/')) {
             platformUrl = platformUrl + '/';
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -559,10 +559,15 @@ export class Utils {
 
     /**
      * Check if the color scheme is supported in the GitHub UI.
-     * Currently, GitHub enterprise does not support the color scheme $\textcolor{}.
+     * Currently, GitHub enterprise does not support the color LaTex scheme $\textcolor{}.
+     * This scheme is part of the LaTeX/Mathematics scheme.
+     *
+     * For more info about the scheme see:
+     * https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
+     *
      * @returns <boolean> true if the color scheme is supported, false otherwise.
      */
-    static isColorSchemeSupported() {
+    static isColorSchemeSupported(): boolean {
         let serverUrl: string = process.env.GITHUB_SERVER_URL || '';
         return serverUrl.startsWith('https://github.com');
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -502,6 +502,7 @@ export class Utils {
                 return;
             }
             // Write to GitHub's job summary
+            core.info(markdownContent);
             core.summary.addRaw(markdownContent, true);
             await core.summary.write({ overwrite: true });
             // Clear files

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -299,3 +299,20 @@ describe('Job Summaries', () => {
         });
     });
 });
+
+describe('isColorSchemeSupported', () => {
+    it('should return true if GITHUB_SERVER_URL includes github.com', () => {
+        process.env.GITHUB_SERVER_URL = 'https://github.com';
+        expect(Utils.isColorSchemeSupported()).toBe(true);
+    });
+
+    it('should return false if GITHUB_SERVER_URL does not include github.com', () => {
+        process.env.GITHUB_SERVER_URL = 'https://enterprise.github.com';
+        expect(Utils.isColorSchemeSupported()).toBe(false);
+    });
+
+    it('should return false if GITHUB_SERVER_URL is undefined', () => {
+        delete process.env.GITHUB_SERVER_URL;
+        expect(Utils.isColorSchemeSupported()).toBe(false);
+    });
+});


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

The color scheme used inside the job summaries is not supported on GitHub's enterprise servers.
Fallback to without color scheme if that's the case.

Color scheme:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions