### PR TITLE
Bump JFrog CLI version to 2.59.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "JFrog"
 inputs:
     version:
         description: "JFrog CLI Version"
-        default: "2.58.2"
+        default: "2.59.1"
         required: false
     download-repository:
         description: "Remote repository in Artifactory pointing to 'https://releases.jfrog.io/artifactory/jfrog-cli'. Use this parameter in case you don't have an Internet access."


### PR DESCRIPTION
Bumb JFrog CLI version to 2.59.1

- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
