### PR TITLE
Reorder job summary sections

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -494,19 +494,23 @@ class Utils {
         return __awaiter(this, void 0, void 0, function* () {
             const outputDir = Utils.getJobOutputDirectoryPath();
             let markdownContent = '';
+            const sectionContents = {};
+            // Read all sections.
             for (const sectionName of Utils.JOB_SUMMARY_MARKDOWN_SECTIONS_NAMES) {
                 const fullPath = path.join(outputDir, sectionName, 'markdown.md');
-                // Check file exists
-                if (!(0, fs_1.existsSync)(fullPath)) {
-                    continue;
+                if ((0, fs_1.existsSync)(fullPath)) {
+                    sectionContents[sectionName] = yield Utils.readSummarySection(fullPath, sectionName);
                 }
-                markdownContent += yield Utils.readSummarySection(fullPath, sectionName);
             }
-            // No section was added, return empty string
-            if (markdownContent == '') {
-                return '';
+            // If build info was published, remove generic upload section to avoid duplications with generic modules.
+            if (sectionContents[MarkdownSection.BuildInfo] != '') {
+                sectionContents[MarkdownSection.Upload] = '';
             }
-            return Utils.wrapContent(markdownContent);
+            // Append sections in order.
+            for (const sectionName of Utils.JOB_SUMMARY_MARKDOWN_SECTIONS_NAMES) {
+                markdownContent += sectionContents[sectionName] || '';
+            }
+            return markdownContent ? Utils.wrapContent(markdownContent) : '';
         });
     }
     static readSummarySection(fullPath, section) {
@@ -623,11 +627,11 @@ Utils.LATEST_RELEASE_VERSION = '[RELEASE]';
 Utils.SETUP_JFROG_CLI_SERVER_ID = 'setup-jfrog-cli-server';
 // Directory name which holds markdown files for the Workflow summary
 Utils.JOB_SUMMARY_DIR_NAME = 'jfrog-command-summary';
-// Workflow summary section files
+// Workflow summary section files. Order of sections in this array impacts the order in the final markdown.
 Utils.JOB_SUMMARY_MARKDOWN_SECTIONS_NAMES = [
-    MarkdownSection.Upload,
-    MarkdownSection.BuildInfo,
     MarkdownSection.Security,
+    MarkdownSection.BuildInfo,
+    MarkdownSection.Upload,
 ];
 // Inputs
 // Version input


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
The upcoming release of JFrog CLI will include modules of Build Info in the summary.
This PR reorders the sections in the job summary and handles possible duplications of generic modules.