### PR TITLE
Fix missing cached JFrog CLI path on cleanup task

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -240,6 +240,8 @@ class Utils {
         if (jfExecDir && jfrogExecDir) {
             core.addPath(jfExecDir);
             core.addPath(jfrogExecDir);
+            // Save the JF CLI path to use on cleanup. saveState/getState are methods to pass data between a step, and it's cleanup function.
+            core.saveState(Utils.JF_CLI_PATH_STATE, jfExecDir);
             return true;
         }
         return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import { exec, ExecOptions, ExecOutput, getExecOutput } from '@actions/exec';
 import { HttpClient, HttpClientResponse } from '@actions/http-client';
 import * as toolCache from '@actions/tool-cache';
-import { chmodSync, existsSync, mkdirSync, promises as fs } from 'fs';
+import { chmodSync, existsSync, promises as fs } from 'fs';
 import { OutgoingHttpHeaders } from 'http';
 import { arch, platform, tmpdir } from 'os';
 import * as path from 'path';
@@ -265,6 +265,8 @@ export class Utils {
         if (jfExecDir && jfrogExecDir) {
             core.addPath(jfExecDir);
             core.addPath(jfrogExecDir);
+            // Save the JF CLI path to use on cleanup. saveState/getState are methods to pass data between a step, and it's cleanup function.
+            core.saveState(Utils.JF_CLI_PATH_STATE, jfExecDir);
             return true;
         }
         return false;


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
should fix https://github.com/jfrog/setup-jfrog-cli/issues/196