### PR TITLE
Remove unnecessary warnings on post cleanup

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -60,7 +60,7 @@ function autoPublishBuildsAndGenerateSummary() {
     return __awaiter(this, void 0, void 0, function* () {
         // First we check for compatible CLI version
         let supported = yield supportedCliVersion();
-        core.info("JFrog CLI version is compatible: " + supported);
+        core.info('JFrog CLI version is compatible: ' + supported);
         if (supported) {
             // Auto-publish build info if needed
             try {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -62,6 +62,7 @@ function cleanup() {
 }
 /**
  * Auto-publish unpublished builds and generate job summary if CLI version is compatible
+ * The logs are debug logs to avoid alarming users who cannot use this features
  */
 function autoPublishBuildsAndGenerateSummary() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -77,7 +78,7 @@ function autoPublishBuildsAndGenerateSummary() {
             }
         }
         catch (error) {
-            core.warning('failed while attempting to publish build info: ' + error);
+            core.debug('failed while attempting to publish build info: ' + error);
         }
         // Generate job summary
         try {
@@ -89,7 +90,7 @@ function autoPublishBuildsAndGenerateSummary() {
             }
         }
         catch (error) {
-            core.warning('failed while attempting to generate job summary: ' + error);
+            core.debug('failed while attempting to generate job summary: ' + error);
         }
     });
 }
@@ -113,7 +114,7 @@ function hasUnpublishedModules(workingDirectory) {
             // Running build-publish command with a dry-run flag to check if there are any unpublished modules, 'silent' to avoid polluting the logs
             const responseStr = yield utils_1.Utils.runCliAndGetOutput(['rt', 'build-publish', '--dry-run'], {
                 silent: true,
-                cwd: workingDirectory,
+                cwd: workingDirectory
             });
             // Parse the JSON string to an object
             const response = JSON.parse(responseStr);

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -31,10 +31,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.supportedCliVersion = supportedCliVersion;
 const core = __importStar(require("@actions/core"));
 const utils_1 = require("./utils");
+const preload_1 = __importDefault(require("semver/preload"));
 function cleanup() {
     return __awaiter(this, void 0, void 0, function* () {
         if (!addCachedJfToPath()) {
@@ -60,7 +64,6 @@ function autoPublishBuildsAndGenerateSummary() {
     return __awaiter(this, void 0, void 0, function* () {
         // First we check for compatible CLI version
         let supported = yield supportedCliVersion();
-        core.info('JFrog CLI version is compatible: ' + supported);
         if (supported) {
             // Auto-publish build info if needed
             try {
@@ -158,7 +161,7 @@ function supportedCliVersion() {
         if (!cliVersion) {
             return false;
         }
-        return isVersionGreaterThan(cliVersion, utils_1.Utils.minJobSummaryCLIVersion);
+        return preload_1.default.gte(cliVersion, utils_1.Utils.minJobSummaryCLIVersion);
     });
 }
 function getCliVersion() {
@@ -173,16 +176,5 @@ function getCliVersion() {
             return null;
         }
     });
-}
-function isVersionGreaterThan(currentVersion, targetVersion) {
-    const currentParts = currentVersion.split('.').map(Number);
-    const targetParts = targetVersion.split('.').map(Number);
-    for (let i = 0; i < targetParts.length; i++) {
-        if (currentParts[i] > targetParts[i])
-            return true;
-        if (currentParts[i] < targetParts[i])
-            return false;
-    }
-    return true; // Return true if all parts are equal
 }
 cleanup();

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -60,34 +60,36 @@ function cleanup() {
         }
     });
 }
+/**
+ * Auto-publish unpublished builds and generate job summary if CLI version is compatible
+ */
 function autoPublishBuildsAndGenerateSummary() {
     return __awaiter(this, void 0, void 0, function* () {
-        // First we check for compatible CLI version
-        let supported = yield supportedCliVersion();
-        if (supported) {
-            // Auto-publish build info if needed
-            try {
-                if (!core.getBooleanInput(utils_1.Utils.AUTO_BUILD_PUBLISH_DISABLE)) {
-                    core.startGroup('Auto-publishing build info to JFrog Artifactory');
-                    yield collectAndPublishBuildInfoIfNeeded();
-                    core.endGroup();
-                }
+        if (!(yield supportedCliVersion(utils_1.Utils.minJobSummaryCLIVersion))) {
+            return;
+        }
+        // Auto-publish build info and collect git information
+        try {
+            if (!core.getBooleanInput(utils_1.Utils.AUTO_BUILD_PUBLISH_DISABLE)) {
+                core.startGroup('Auto-publishing build info to JFrog Artifactory');
+                yield collectAndPublishBuildInfoIfNeeded();
+                core.endGroup();
             }
-            catch (error) {
-                core.warning('failed while attempting to publish build info: ' + error);
+        }
+        catch (error) {
+            core.warning('failed while attempting to publish build info: ' + error);
+        }
+        // Generate job summary
+        try {
+            if (!core.getBooleanInput(utils_1.Utils.JOB_SUMMARY_DISABLE)) {
+                core.startGroup('Generating Job Summary');
+                yield utils_1.Utils.runCli(['generate-summary-markdown']);
+                yield utils_1.Utils.setMarkdownAsJobSummary();
+                core.endGroup();
             }
-            // Generate job summary
-            try {
-                if (!core.getBooleanInput(utils_1.Utils.JOB_SUMMARY_DISABLE)) {
-                    core.startGroup('Generating Job Summary');
-                    yield utils_1.Utils.runCli(['generate-summary-markdown']);
-                    yield utils_1.Utils.setMarkdownAsJobSummary();
-                    core.endGroup();
-                }
-            }
-            catch (error) {
-                core.warning('failed while attempting to generate job summary: ' + error);
-            }
+        }
+        catch (error) {
+            core.warning('failed while attempting to generate job summary: ' + error);
         }
     });
 }
@@ -109,7 +111,10 @@ function hasUnpublishedModules(workingDirectory) {
             // Avoid saving a command summary for this dry-run command
             core.exportVariable(utils_1.Utils.JFROG_CLI_COMMAND_SUMMARY_OUTPUT_DIR_ENV, '');
             // Running build-publish command with a dry-run flag to check if there are any unpublished modules, 'silent' to avoid polluting the logs
-            const responseStr = yield utils_1.Utils.runCliAndGetOutput(['rt', 'build-publish', '--dry-run'], { silent: true, cwd: workingDirectory });
+            const responseStr = yield utils_1.Utils.runCliAndGetOutput(['rt', 'build-publish', '--dry-run'], {
+                silent: true,
+                cwd: workingDirectory,
+            });
             // Parse the JSON string to an object
             const response = JSON.parse(responseStr);
             // Check if the "modules" key exists and if it's an array with more than one item
@@ -155,13 +160,16 @@ function getWorkingDirectory() {
     }
     return workingDirectory;
 }
-function supportedCliVersion() {
+/**
+ * Check if the installed JFrog CLI version equal or greater than the minimum supplied
+ */
+function supportedCliVersion(minimumVersion) {
     return __awaiter(this, void 0, void 0, function* () {
         let cliVersion = yield getCliVersion();
         if (!cliVersion) {
             return false;
         }
-        return preload_1.default.gte(cliVersion, utils_1.Utils.minJobSummaryCLIVersion);
+        return preload_1.default.gte(cliVersion, minimumVersion);
     });
 }
 function getCliVersion() {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -165,24 +165,17 @@ function getWorkingDirectory() {
  */
 function supportedCliVersion(minimumVersion) {
     return __awaiter(this, void 0, void 0, function* () {
-        let cliVersion = yield getCliVersion();
-        if (!cliVersion) {
+        let cliVersionOutput = yield utils_1.Utils.runCliAndGetOutput(['--version']);
+        if (!cliVersionOutput) {
             return false;
         }
+        // Extract the version number using a regular expression
+        const versionMatch = cliVersionOutput.match(/jf version (\d+\.\d+\.\d+)/);
+        if (!versionMatch) {
+            return false;
+        }
+        const cliVersion = versionMatch[1];
         return preload_1.default.gte(cliVersion, minimumVersion);
-    });
-}
-function getCliVersion() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            const versionOutput = yield utils_1.Utils.runCliAndGetOutput(['--version']);
-            const versionMatch = versionOutput.match(/jf version (\d+\.\d+\.\d+)/);
-            return versionMatch ? versionMatch[1] : null;
-        }
-        catch (error) {
-            core.warning('Failed to get JFrog CLI version: ' + error);
-            return null;
-        }
     });
 }
 cleanup();

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -178,9 +178,9 @@ function isVersionGreaterThan(currentVersion, targetVersion) {
     const currentParts = currentVersion.split('.').map(Number);
     const targetParts = targetVersion.split('.').map(Number);
     for (let i = 0; i < targetParts.length; i++) {
-        if (currentParts[i] > targetParts[i])
+        if (currentParts[i] >= targetParts[i])
             return true;
-        if (currentParts[i] < targetParts[i])
+        if (currentParts[i] <= targetParts[i])
             return false;
     }
     return false;

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -32,6 +32,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.supportedCliVersion = supportedCliVersion;
 const core = __importStar(require("@actions/core"));
 const utils_1 = require("./utils");
 function cleanup() {
@@ -40,27 +41,8 @@ function cleanup() {
             core.error('Could not find JFrog CLI path in the step state. Skipping cleanup.');
             return;
         }
-        // Auto-publish build info if needed
-        try {
-            if (!core.getBooleanInput(utils_1.Utils.AUTO_BUILD_PUBLISH_DISABLE)) {
-                yield collectAndPublishBuildInfoIfNeeded();
-            }
-        }
-        catch (error) {
-            core.warning('failed while attempting to publish build info: ' + error);
-        }
-        // Generate job summary
-        try {
-            if (!core.getBooleanInput(utils_1.Utils.JOB_SUMMARY_DISABLE)) {
-                core.startGroup('Generating Job Summary');
-                yield utils_1.Utils.runCli(['generate-summary-markdown']);
-                yield utils_1.Utils.setMarkdownAsJobSummary();
-                core.endGroup();
-            }
-        }
-        catch (error) {
-            core.warning('failed while attempting to generate job summary: ' + error);
-        }
+        // Auto publish builds and generate job summary if CLI version is compatible
+        yield autoPublishBuildsAndGenerateSummary();
         // Cleanup JFrog CLI servers configuration
         try {
             core.startGroup('Cleanup JFrog CLI servers configuration');
@@ -71,6 +53,35 @@ function cleanup() {
         }
         finally {
             core.endGroup();
+        }
+    });
+}
+function autoPublishBuildsAndGenerateSummary() {
+    return __awaiter(this, void 0, void 0, function* () {
+        // First we check for compatible CLI version
+        let supported = yield supportedCliVersion();
+        if (supported) {
+            // Auto-publish build info if needed
+            try {
+                if (!core.getBooleanInput(utils_1.Utils.AUTO_BUILD_PUBLISH_DISABLE)) {
+                    yield collectAndPublishBuildInfoIfNeeded();
+                }
+            }
+            catch (error) {
+                core.warning('failed while attempting to publish build info: ' + error);
+            }
+            // Generate job summary
+            try {
+                if (!core.getBooleanInput(utils_1.Utils.JOB_SUMMARY_DISABLE)) {
+                    core.startGroup('Generating Job Summary');
+                    yield utils_1.Utils.runCli(['generate-summary-markdown']);
+                    yield utils_1.Utils.setMarkdownAsJobSummary();
+                    core.endGroup();
+                }
+            }
+            catch (error) {
+                core.warning('failed while attempting to generate job summary: ' + error);
+            }
         }
     });
 }
@@ -137,5 +148,38 @@ function getWorkingDirectory() {
         throw new Error('GITHUB_WORKSPACE is not defined.');
     }
     return workingDirectory;
+}
+function supportedCliVersion() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let cliVersion = yield getCliVersion();
+        if (!cliVersion) {
+            return false;
+        }
+        return isVersionGreaterThan(cliVersion, utils_1.Utils.minJobSummaryCLIVersion);
+    });
+}
+function getCliVersion() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const versionOutput = yield utils_1.Utils.runCliAndGetOutput(['--version']);
+            const versionMatch = versionOutput.match(/jf version (\d+\.\d+\.\d+)/);
+            return versionMatch ? versionMatch[1] : null;
+        }
+        catch (error) {
+            core.warning('Failed to get JFrog CLI version: ' + error);
+            return null;
+        }
+    });
+}
+function isVersionGreaterThan(currentVersion, targetVersion) {
+    const currentParts = currentVersion.split('.').map(Number);
+    const targetParts = targetVersion.split('.').map(Number);
+    for (let i = 0; i < targetParts.length; i++) {
+        if (currentParts[i] > targetParts[i])
+            return true;
+        if (currentParts[i] < targetParts[i])
+            return false;
+    }
+    return false;
 }
 cleanup();

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -60,11 +60,14 @@ function autoPublishBuildsAndGenerateSummary() {
     return __awaiter(this, void 0, void 0, function* () {
         // First we check for compatible CLI version
         let supported = yield supportedCliVersion();
+        core.info("JFrog CLI version is compatible: " + supported);
         if (supported) {
             // Auto-publish build info if needed
             try {
                 if (!core.getBooleanInput(utils_1.Utils.AUTO_BUILD_PUBLISH_DISABLE)) {
+                    core.startGroup('Auto-publishing build info to JFrog Artifactory');
                     yield collectAndPublishBuildInfoIfNeeded();
+                    core.endGroup();
                 }
             }
             catch (error) {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -35,7 +35,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.supportedCliVersion = supportedCliVersion;
+exports.isCliVersionAtLeast = isCliVersionAtLeast;
 const core = __importStar(require("@actions/core"));
 const utils_1 = require("./utils");
 const preload_1 = __importDefault(require("semver/preload"));
@@ -65,7 +65,7 @@ function cleanup() {
  */
 function autoPublishBuildsAndGenerateSummary() {
     return __awaiter(this, void 0, void 0, function* () {
-        if (!(yield supportedCliVersion(utils_1.Utils.minJobSummaryCLIVersion))) {
+        if (!(yield isCliVersionAtLeast(utils_1.Utils.minJobSummaryCLIVersion))) {
             return;
         }
         // Auto-publish build info and collect git information
@@ -161,20 +161,20 @@ function getWorkingDirectory() {
     return workingDirectory;
 }
 /**
- * Check if the installed JFrog CLI version equal or greater than the minimum supplied
+ * Check if the installed JFrog CLI version is equal to or greater than the minimum supplied
  */
-function supportedCliVersion(minimumVersion) {
+function isCliVersionAtLeast(minimumVersion) {
     return __awaiter(this, void 0, void 0, function* () {
         let cliVersionOutput = yield utils_1.Utils.runCliAndGetOutput(['--version']);
         if (!cliVersionOutput) {
             return false;
         }
-        // Extract the version number using a regular expression
-        const versionMatch = cliVersionOutput.match(/jf version (\d+\.\d+\.\d+)/);
-        if (!versionMatch) {
+        // Extract the version number assuming the format is always "jf version x.y.z"
+        const cliVersionParts = cliVersionOutput.split(' ');
+        if (cliVersionParts.length < 3) {
             return false;
         }
-        const cliVersion = versionMatch[1];
+        const cliVersion = cliVersionParts[2];
         return preload_1.default.gte(cliVersion, minimumVersion);
     });
 }

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -178,11 +178,11 @@ function isVersionGreaterThan(currentVersion, targetVersion) {
     const currentParts = currentVersion.split('.').map(Number);
     const targetParts = targetVersion.split('.').map(Number);
     for (let i = 0; i < targetParts.length; i++) {
-        if (currentParts[i] >= targetParts[i])
+        if (currentParts[i] > targetParts[i])
             return true;
-        if (currentParts[i] <= targetParts[i])
+        if (currentParts[i] < targetParts[i])
             return false;
     }
-    return false;
+    return true; // Return true if all parts are equal
 }
 cleanup();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -647,3 +647,5 @@ Utils.AUTO_BUILD_PUBLISH_DISABLE = 'disable-auto-build-publish';
 // It cannot be linked to the repository, as GitHub serves the image from a CDN,
 // which gets blocked by the browser, resulting in an empty image.
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
+// Sets the minimum version of the Job Summaries which includes auto build publishing.
+Utils.minJobSummaryCLIVersion = '2.66.0';

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -23,6 +23,7 @@ async function cleanup() {
 
 /**
  * Auto-publish unpublished builds and generate job summary if CLI version is compatible
+ * The logs are debug logs to avoid alarming users who cannot use this features
  */
 async function autoPublishBuildsAndGenerateSummary() {
     if (!(await isCliVersionAtLeast(Utils.minJobSummaryCLIVersion))) {
@@ -36,7 +37,7 @@ async function autoPublishBuildsAndGenerateSummary() {
             core.endGroup();
         }
     } catch (error) {
-        core.warning('failed while attempting to publish build info: ' + error);
+        core.debug('failed while attempting to publish build info: ' + error);
     }
     // Generate job summary
     try {
@@ -47,7 +48,7 @@ async function autoPublishBuildsAndGenerateSummary() {
             core.endGroup();
         }
     } catch (error) {
-        core.warning('failed while attempting to generate job summary: ' + error);
+        core.debug('failed while attempting to generate job summary: ' + error);
     }
 }
 

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -142,8 +142,8 @@ function isVersionGreaterThan(currentVersion: string, targetVersion: string): bo
     const targetParts: number[] = targetVersion.split('.').map(Number);
 
     for (let i: number = 0; i < targetParts.length; i++) {
-        if (currentParts[i] > targetParts[i]) return true;
-        if (currentParts[i] < targetParts[i]) return false;
+        if (currentParts[i] >= targetParts[i]) return true;
+        if (currentParts[i] <= targetParts[i]) return false;
     }
     return false;
 }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import { Utils } from './utils';
+import semver from 'semver/preload';
 
 async function cleanup() {
     if (!addCachedJfToPath()) {
@@ -23,7 +24,6 @@ async function cleanup() {
 async function autoPublishBuildsAndGenerateSummary() {
     // First we check for compatible CLI version
     let supported: boolean = await supportedCliVersion();
-    core.info('JFrog CLI version is compatible: ' + supported);
     if (supported) {
         // Auto-publish build info if needed
         try {
@@ -123,7 +123,7 @@ export async function supportedCliVersion(): Promise<boolean> {
     if (!cliVersion) {
         return false;
     }
-    return isVersionGreaterThan(cliVersion, Utils.minJobSummaryCLIVersion);
+    return semver.gte(cliVersion, Utils.minJobSummaryCLIVersion);
 }
 
 async function getCliVersion(): Promise<string | null> {
@@ -135,17 +135,6 @@ async function getCliVersion(): Promise<string | null> {
         core.warning('Failed to get JFrog CLI version: ' + error);
         return null;
     }
-}
-
-function isVersionGreaterThan(currentVersion: string, targetVersion: string): boolean {
-    const currentParts: number[] = currentVersion.split('.').map(Number);
-    const targetParts: number[] = targetVersion.split('.').map(Number);
-
-    for (let i: number = 0; i < targetParts.length; i++) {
-        if (currentParts[i] > targetParts[i]) return true;
-        if (currentParts[i] < targetParts[i]) return false;
-    }
-    return true; // Return true if all parts are equal
 }
 
 cleanup();

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -142,10 +142,10 @@ function isVersionGreaterThan(currentVersion: string, targetVersion: string): bo
     const targetParts: number[] = targetVersion.split('.').map(Number);
 
     for (let i: number = 0; i < targetParts.length; i++) {
-        if (currentParts[i] >= targetParts[i]) return true;
-        if (currentParts[i] <= targetParts[i]) return false;
+        if (currentParts[i] > targetParts[i]) return true;
+        if (currentParts[i] < targetParts[i]) return false;
     }
-    return false;
+    return true; // Return true if all parts are equal
 }
 
 cleanup();

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -23,11 +23,14 @@ async function cleanup() {
 async function autoPublishBuildsAndGenerateSummary() {
     // First we check for compatible CLI version
     let supported: boolean = await supportedCliVersion();
+    core.info('JFrog CLI version is compatible: ' + supported);
     if (supported) {
         // Auto-publish build info if needed
         try {
             if (!core.getBooleanInput(Utils.AUTO_BUILD_PUBLISH_DISABLE)) {
+                core.startGroup('Auto-publishing build info to JFrog Artifactory');
                 await collectAndPublishBuildInfoIfNeeded();
+                core.endGroup();
             }
         } catch (error) {
             core.warning('failed while attempting to publish build info: ' + error);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -25,7 +25,7 @@ async function cleanup() {
  * Auto-publish unpublished builds and generate job summary if CLI version is compatible
  */
 async function autoPublishBuildsAndGenerateSummary() {
-    if (!(await supportedCliVersion(Utils.minJobSummaryCLIVersion))) {
+    if (!(await isCliVersionAtLeast(Utils.minJobSummaryCLIVersion))) {
         return;
     }
     // Auto-publish build info and collect git information
@@ -124,21 +124,21 @@ function getWorkingDirectory(): string {
 }
 
 /**
- * Check if the installed JFrog CLI version equal or greater than the minimum supplied
+ * Check if the installed JFrog CLI version is equal to or greater than the minimum supplied
  */
-export async function supportedCliVersion(minimumVersion: string): Promise<boolean> {
+export async function isCliVersionAtLeast(minimumVersion: string): Promise<boolean> {
     let cliVersionOutput: string | null = await Utils.runCliAndGetOutput(['--version']);
     if (!cliVersionOutput) {
         return false;
     }
 
-    // Extract the version number using a regular expression
-    const versionMatch: RegExpMatchArray | null = cliVersionOutput.match(/jf version (\d+\.\d+\.\d+)/);
-    if (!versionMatch) {
+    // Extract the version number assuming the format is always "jf version x.y.z"
+    const cliVersionParts: string[] = cliVersionOutput.split(' ');
+    if (cliVersionParts.length < 3) {
         return false;
     }
 
-    const cliVersion: string = versionMatch[1];
+    const cliVersion: string = cliVersionParts[2];
     return semver.gte(cliVersion, minimumVersion);
 }
 

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -127,22 +127,19 @@ function getWorkingDirectory(): string {
  * Check if the installed JFrog CLI version equal or greater than the minimum supplied
  */
 export async function supportedCliVersion(minimumVersion: string): Promise<boolean> {
-    let cliVersion: string | null = await getCliVersion();
-    if (!cliVersion) {
+    let cliVersionOutput: string | null = await Utils.runCliAndGetOutput(['--version']);
+    if (!cliVersionOutput) {
         return false;
     }
-    return semver.gte(cliVersion, minimumVersion);
-}
 
-async function getCliVersion(): Promise<string | null> {
-    try {
-        const versionOutput: string = await Utils.runCliAndGetOutput(['--version']);
-        const versionMatch: RegExpMatchArray | null = versionOutput.match(/jf version (\d+\.\d+\.\d+)/);
-        return versionMatch ? versionMatch[1] : null;
-    } catch (error) {
-        core.warning('Failed to get JFrog CLI version: ' + error);
-        return null;
+    // Extract the version number using a regular expression
+    const versionMatch: RegExpMatchArray | null = cliVersionOutput.match(/jf version (\d+\.\d+\.\d+)/);
+    if (!versionMatch) {
+        return false;
     }
+
+    const cliVersion: string = versionMatch[1];
+    return semver.gte(cliVersion, minimumVersion);
 }
 
 cleanup();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,8 @@ export class Utils {
     // which gets blocked by the browser, resulting in an empty image.
     private static MARKDOWN_HEADER_PNG_URL: string = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
     private static isSummaryHeaderAccessible: boolean;
+    // Sets the minimum version of the Job Summaries which includes auto build publishing.
+    public static minJobSummaryCLIVersion: string = '2.66.0';
 
     /**
      * Retrieves server credentials for accessing JFrog's server

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -384,12 +384,6 @@ describe('supportedCliVersion', () => {
         expect(result).toBe(false);
     });
 
-    it('should return false for CLI version equal to 2.66.0', async () => {
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.66.0');
-        const result: boolean = await supportedCliVersion();
-        expect(result).toBe(false);
-    });
-
     it('should return false if CLI version cannot be determined', async () => {
         jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('unknown version');
         const result: boolean = await supportedCliVersion();

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -365,7 +365,9 @@ describe('Job Summaries', () => {
     });
 });
 
-describe('supportedCliVersion', () => {
+// Verify the Auto Build Publish feature, and the Job summaries
+// are using CLI version 2.66.0 and above.
+describe('AutoPublishSupportedCliVersion', () => {
     it('should return true for CLI version greater than 2.66.0', async () => {
         jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.67.0');
         const result: boolean = await supportedCliVersion();

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -372,6 +372,12 @@ describe('supportedCliVersion', () => {
         expect(result).toBe(true);
     });
 
+    it('should return true for CLI version greater or equal to 2.66.0', async () => {
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.66.0');
+        const result: boolean = await supportedCliVersion();
+        expect(result).toBe(true);
+    });
+
     it('should return false for CLI version less than 2.66.0', async () => {
         jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.65.0');
         const result: boolean = await supportedCliVersion();

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -365,36 +365,32 @@ describe('Job Summaries', () => {
     });
 });
 
-// Verify the Auto Build Publish feature, and the Job summaries
-// are using CLI version 2.66.0 and above.
 describe('AutoPublishSupportedCliVersion', () => {
     it('should return true for CLI version greater than 2.66.0', async () => {
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.67.0');
-        const result: boolean = await supportedCliVersion();
+        let testCliVersion: string = '2.67.0';
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
+        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(true);
     });
 
     it('should return true for CLI version greater or equal to 2.66.0', async () => {
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.66.0');
-        const result: boolean = await supportedCliVersion();
+        let testCliVersion: string = '2.66.0';
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
+        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(true);
     });
 
     it('should return false for CLI version less than 2.66.0', async () => {
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.65.0');
-        const result: boolean = await supportedCliVersion();
+        let testCliVersion: string = '2.65.0';
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
+        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(false);
     });
 
     it('should return false if CLI version cannot be determined', async () => {
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('unknown version');
-        const result: boolean = await supportedCliVersion();
-        expect(result).toBe(false);
-    });
-
-    it('should return false if an error occurs while getting CLI version', async () => {
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockRejectedValue(new Error('Failed to get version'));
-        const result: boolean = await supportedCliVersion();
+        let testCliVersion: string = 'unknown version';
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
+        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(false);
     });
 });

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import * as core from '@actions/core';
 import { Utils, DownloadDetails, JfrogCredentials, JWTTokenData } from '../src/utils';
-import { supportedCliVersion } from '../src/cleanup';
+import { isCliVersionAtLeast } from '../src/cleanup';
 jest.mock('os');
 jest.mock('@actions/core');
 
@@ -369,28 +369,21 @@ describe('AutoPublishSupportedCliVersion', () => {
     it('should return true for CLI version greater than 2.66.0', async () => {
         let testCliVersion: string = '2.67.0';
         jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
-        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
+        const result: boolean = await isCliVersionAtLeast(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(true);
     });
 
     it('should return true for CLI version greater or equal to 2.66.0', async () => {
         let testCliVersion: string = '2.66.0';
         jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
-        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
+        const result: boolean = await isCliVersionAtLeast(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(true);
     });
 
     it('should return false for CLI version less than 2.66.0', async () => {
         let testCliVersion: string = '2.65.0';
         jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
-        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
-        expect(result).toBe(false);
-    });
-
-    it('should return false if CLI version cannot be determined', async () => {
-        let testCliVersion: string = 'unknown version';
-        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue(`jf version ${testCliVersion}`);
-        const result: boolean = await supportedCliVersion(Utils.minJobSummaryCLIVersion);
+        const result: boolean = await isCliVersionAtLeast(Utils.minJobSummaryCLIVersion);
         expect(result).toBe(false);
     });
 });

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,8 +1,7 @@
 import * as os from 'os';
 import * as core from '@actions/core';
-
 import { Utils, DownloadDetails, JfrogCredentials, JWTTokenData } from '../src/utils';
-import { tmpdir } from 'os';
+import { supportedCliVersion } from '../src/cleanup';
 jest.mock('os');
 jest.mock('@actions/core');
 
@@ -363,5 +362,37 @@ describe('Job Summaries', () => {
             // Restore the mock to avoid affecting other tests
             jest.restoreAllMocks();
         });
+    });
+});
+
+describe('supportedCliVersion', () => {
+    it('should return true for CLI version greater than 2.66.0', async () => {
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.67.0');
+        const result: boolean = await supportedCliVersion();
+        expect(result).toBe(true);
+    });
+
+    it('should return false for CLI version less than 2.66.0', async () => {
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.65.0');
+        const result: boolean = await supportedCliVersion();
+        expect(result).toBe(false);
+    });
+
+    it('should return false for CLI version equal to 2.66.0', async () => {
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('jf version 2.66.0');
+        const result: boolean = await supportedCliVersion();
+        expect(result).toBe(false);
+    });
+
+    it('should return false if CLI version cannot be determined', async () => {
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockResolvedValue('unknown version');
+        const result: boolean = await supportedCliVersion();
+        expect(result).toBe(false);
+    });
+
+    it('should return false if an error occurs while getting CLI version', async () => {
+        jest.spyOn(Utils, 'runCliAndGetOutput').mockRejectedValue(new Error('Failed to get version'));
+        const result: boolean = await supportedCliVersion();
+        expect(result).toBe(false);
     });
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Summary:

During post-cleanup, we attempt to publish build info and generate a job summary. While these are valuable features, errors in these tasks shouldn't unnecessarily alarm users.

Details:

This PR adds a check for a valid CLI version and moves related logs to the debug level, ensuring that users aren't alerted by errors they can't address themselves.

