### PR TITLE
Avoid throwing on JFrog CLI execution failures

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -408,9 +408,9 @@ class Utils {
      */
     static runCli(args, options) {
         return __awaiter(this, void 0, void 0, function* () {
-            let res = yield (0, exec_1.exec)('jf', args, options);
+            let res = yield (0, exec_1.exec)('jf', args, Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
             if (res !== core.ExitCode.Success) {
-                throw new Error('JFrog CLI exited with exit code ' + res);
+                throw new Error('JFrog CLI exited with exit code: ' + res);
             }
         });
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -462,9 +462,9 @@ export class Utils {
      * @param options - Execution options
      */
     public static async runCli(args: string[], options?: ExecOptions) {
-        let res: number = await exec('jf', args, options);
+        let res: number = await exec('jf', args, { ...options, ignoreReturnCode: true });
         if (res !== core.ExitCode.Success) {
-            throw new Error('JFrog CLI exited with exit code ' + res);
+            throw new Error('JFrog CLI exited with exit code: ' + res);
         }
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Instead of throwing in execution, catch the error and throw it through the action.