### PR TITLE
Remove redundant chmod on cached executable

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -239,10 +239,6 @@ class Utils {
         if (jfExecDir && jfrogExecDir) {
             core.addPath(jfExecDir);
             core.addPath(jfrogExecDir);
-            if (!Utils.isWindows()) {
-                (0, fs_1.chmodSync)((0, path_1.join)(jfExecDir, jfFileName), 0o555);
-                (0, fs_1.chmodSync)((0, path_1.join)(jfrogExecDir, jfrogFileName), 0o555);
-            }
             return true;
         }
         return false;
@@ -264,6 +260,10 @@ class Utils {
             core.addPath(jfCacheDir);
             let jfrogCacheDir = yield toolCache.cacheFile(downloadedExecutable, jfrogFileName, jfrogFileName, version);
             core.addPath(jfrogCacheDir);
+            if (!Utils.isWindows()) {
+                (0, fs_1.chmodSync)((0, path_1.join)(jfCacheDir, jfFileName), 0o555);
+                (0, fs_1.chmodSync)((0, path_1.join)(jfrogCacheDir, jfrogFileName), 0o555);
+            }
         });
     }
     /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -264,10 +264,6 @@ class Utils {
             core.addPath(jfCacheDir);
             let jfrogCacheDir = yield toolCache.cacheFile(downloadedExecutable, jfrogFileName, jfrogFileName, version);
             core.addPath(jfrogCacheDir);
-            if (!Utils.isWindows()) {
-                (0, fs_1.chmodSync)((0, path_1.join)(jfCacheDir, jfFileName), 0o555);
-                (0, fs_1.chmodSync)((0, path_1.join)(jfrogCacheDir, jfrogFileName), 0o555);
-            }
         });
     }
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -300,11 +300,6 @@ export class Utils {
 
         let jfrogCacheDir: string = await toolCache.cacheFile(downloadedExecutable, jfrogFileName, jfrogFileName, version);
         core.addPath(jfrogCacheDir);
-
-        if (!Utils.isWindows()) {
-            chmodSync(join(jfCacheDir, jfFileName), 0o555);
-            chmodSync(join(jfrogCacheDir, jfrogFileName), 0o555);
-        }
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -274,10 +274,6 @@ export class Utils {
             core.addPath(jfExecDir);
             core.addPath(jfrogExecDir);
 
-            if (!Utils.isWindows()) {
-                chmodSync(join(jfExecDir, jfFileName), 0o555);
-                chmodSync(join(jfrogExecDir, jfrogFileName), 0o555);
-            }
             return true;
         }
         return false;
@@ -300,6 +296,11 @@ export class Utils {
 
         let jfrogCacheDir: string = await toolCache.cacheFile(downloadedExecutable, jfrogFileName, jfrogFileName, version);
         core.addPath(jfrogCacheDir);
+
+        if (!Utils.isWindows()) {
+            chmodSync(join(jfCacheDir, jfFileName), 0o555);
+            chmodSync(join(jfrogCacheDir, jfrogFileName), 0o555);
+        }
     }
 
     /**


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
should fix https://github.com/jfrog/setup-jfrog-cli/issues/211
