### PR TITLE
Add Commands for Enhanced Usage Insights

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "JFrog"
 inputs:
     version:
         description: "JFrog CLI Version"
-        default: "2.68.0"
+        default: "2.71.4"
         required: false
     download-repository:
         description: "Remote repository in Artifactory pointing to 'https://releases.jfrog.io/artifactory/jfrog-cli'. Use this parameter in case you don't have an Internet access."

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -140,7 +140,7 @@ function collectAndPublishBuildInfoIfNeeded() {
         try {
             core.startGroup('Publish the build info to JFrog Artifactory');
             // Used for usage reporting
-            core.exportVariable("JFROG_CLI_AUTO_PUBLISHED", "TRUE");
+            core.exportVariable("JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO", "TRUE");
             yield utils_1.Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
         }
         catch (error) {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -141,7 +141,7 @@ function collectAndPublishBuildInfoIfNeeded() {
             core.startGroup('Publish the build info to JFrog Artifactory');
             // Set the environment variable to indicate that the build has been automatically published.
             // This is used by the usage report to track instances of automatic build publication.
-            core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
+            core.exportVariable('JFROG_CLI_USAGE_AUTO_BUILD_PUBLISHED', 'TRUE');
             yield utils_1.Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
         }
         catch (error) {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -139,8 +139,9 @@ function collectAndPublishBuildInfoIfNeeded() {
         // Publish the build info to Artifactory
         try {
             core.startGroup('Publish the build info to JFrog Artifactory');
-            // Used for usage reporting
-            core.exportVariable("JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO", "TRUE");
+            // Set the environment variable to indicate that the build has been automatically published.
+            // This is used by the usage report to track instances of automatic build publication.
+            core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
             yield utils_1.Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
         }
         catch (error) {

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -139,6 +139,8 @@ function collectAndPublishBuildInfoIfNeeded() {
         // Publish the build info to Artifactory
         try {
             core.startGroup('Publish the build info to JFrog Artifactory');
+            // Used for usage reporting
+            core.exportVariable("JFROG_CLI_AUTO_PUBLISHED", "TRUE");
             yield utils_1.Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
         }
         catch (error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,8 +77,7 @@ class Utils {
             try {
                 jfrogCredentials = yield this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
                 // Set environment variable to track OIDC logins in the usage report.
-                core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
-                this.exportVariableIfNotSet('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
+                core.exportVariable('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
                 return jfrogCredentials;
             }
             catch (error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,8 +76,9 @@ class Utils {
             }
             try {
                 jfrogCredentials = yield this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
-                // Export env for usage report after successful OIDC token exchange
-                this.exportVariableIfNotSet("JFROG_CLI_USAGE_CONFIG_OIDC", "TRUE");
+                // Set environment variable to track OIDC logins in the usage report.
+                core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
+                this.exportVariableIfNotSet('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
                 return jfrogCredentials;
             }
             catch (error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,6 +61,8 @@ class Utils {
                 // Use JF_ENV or the credentials found in the environment variables
                 return jfrogCredentials;
             }
+            // Used for usage reporting
+            this.exportVariableIfNotSet("JFROG_CLI_OIDC_CONFIG", "TRUE");
             if (!jfrogCredentials.jfrogUrl) {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,8 +61,6 @@ class Utils {
                 // Use JF_ENV or the credentials found in the environment variables
                 return jfrogCredentials;
             }
-            // Used for usage reporting
-            this.exportVariableIfNotSet("JFROG_CLI_USAGE_CONFIG_OIDC", "TRUE");
             if (!jfrogCredentials.jfrogUrl) {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }
@@ -77,7 +75,10 @@ class Utils {
                 throw new Error(`Getting openID Connect JSON web token failed: ${error.message}`);
             }
             try {
-                return yield this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
+                jfrogCredentials = yield this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
+                // Export env for usage report after successful OIDC token exchange
+                this.exportVariableIfNotSet("JFROG_CLI_USAGE_CONFIG_OIDC", "TRUE");
+                return jfrogCredentials;
             }
             catch (error) {
                 throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,7 +62,7 @@ class Utils {
                 return jfrogCredentials;
             }
             // Used for usage reporting
-            this.exportVariableIfNotSet("JFROG_CLI_OIDC_CONFIG", "TRUE");
+            this.exportVariableIfNotSet("JFROG_CLI_USAGE_CONFIG_OIDC", "TRUE");
             if (!jfrogCredentials.jfrogUrl) {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@jfrog/setup-jfrog-cli",
-            "version": "4.4.1",
+            "version": "4.4.2",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "private": true,
     "description": "Setup JFrog CLI in GitHub Actions",
     "main": "lib/main.js",

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -106,8 +106,9 @@ async function collectAndPublishBuildInfoIfNeeded() {
     // Publish the build info to Artifactory
     try {
         core.startGroup('Publish the build info to JFrog Artifactory');
-        // Used for usage reporting
-        core.exportVariable("JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO", "TRUE");
+        // Set the environment variable to indicate that the build has been automatically published.
+        // This is used by the usage report to track instances of automatic build publication.
+        core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
         await Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
     } catch (error) {
         core.warning('Failed while attempting to publish the build info to JFrog Artifactory: ' + error);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -108,7 +108,7 @@ async function collectAndPublishBuildInfoIfNeeded() {
     try {
         core.startGroup('Publish the build info to JFrog Artifactory');
         // Used for usage reporting
-        core.exportVariable("JFROG_CLI_AUTO_PUBLISHED", "TRUE");
+        core.exportVariable("JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO", "TRUE");
         await Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
     } catch (error) {
         core.warning('Failed while attempting to publish the build info to JFrog Artifactory: ' + error);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -32,7 +32,6 @@ async function cleanup() {
 async function buildInfoPostTasks() {
     const disableAutoBuildPublish: boolean = core.getBooleanInput(Utils.AUTO_BUILD_PUBLISH_DISABLE);
     const disableJobSummary: boolean = core.getBooleanInput(Utils.JOB_SUMMARY_DISABLE) || !Utils.isJobSummarySupported();
-
     if (disableAutoBuildPublish && disableJobSummary) {
         core.info(`Both auto-build-publish and job-summary are disabled. Skipping Build Info post tasks.`);
         return;

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -32,6 +32,7 @@ async function cleanup() {
 async function buildInfoPostTasks() {
     const disableAutoBuildPublish: boolean = core.getBooleanInput(Utils.AUTO_BUILD_PUBLISH_DISABLE);
     const disableJobSummary: boolean = core.getBooleanInput(Utils.JOB_SUMMARY_DISABLE) || !Utils.isJobSummarySupported();
+
     if (disableAutoBuildPublish && disableJobSummary) {
         core.info(`Both auto-build-publish and job-summary are disabled. Skipping Build Info post tasks.`);
         return;
@@ -106,6 +107,8 @@ async function collectAndPublishBuildInfoIfNeeded() {
     // Publish the build info to Artifactory
     try {
         core.startGroup('Publish the build info to JFrog Artifactory');
+        // Used for usage reporting
+        core.exportVariable("JFROG_CLI_AUTO_PUBLISHED", "TRUE");
         await Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
     } catch (error) {
         core.warning('Failed while attempting to publish the build info to JFrog Artifactory: ' + error);

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -108,7 +108,7 @@ async function collectAndPublishBuildInfoIfNeeded() {
         core.startGroup('Publish the build info to JFrog Artifactory');
         // Set the environment variable to indicate that the build has been automatically published.
         // This is used by the usage report to track instances of automatic build publication.
-        core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
+        core.exportVariable('JFROG_CLI_USAGE_AUTO_BUILD_PUBLISHED', 'TRUE');
         await Utils.runCli(['rt', 'build-publish'], { cwd: workingDirectory });
     } catch (error) {
         core.warning('Failed while attempting to publish the build info to JFrog Artifactory: ' + error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export class Utils {
     // OpenID Connect audience input
     private static readonly OIDC_AUDIENCE_ARG: string = 'oidc-audience';
     // OpenID Connect provider_name input
-    static readonly OIDC_INTEGRATION_PROVIDER_NAME: string = 'oidc-provider-name';
+    private static readonly OIDC_INTEGRATION_PROVIDER_NAME: string = 'oidc-provider-name';
     // Disable Job Summaries feature flag
     public static readonly JOB_SUMMARY_DISABLE: string = 'disable-job-summary';
     // Disable auto build info publish feature flag

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,8 +82,6 @@ export class Utils {
             return jfrogCredentials;
         }
 
-        // Used for usage reporting
-        this.exportVariableIfNotSet("JFROG_CLI_USAGE_CONFIG_OIDC","TRUE")
         if (!jfrogCredentials.jfrogUrl) {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }
@@ -98,7 +96,11 @@ export class Utils {
         }
 
         try {
-            return await this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
+            jfrogCredentials = await this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
+            // Set environment variable to track OIDC logins in the usage report.
+            core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
+            this.exportVariableIfNotSet('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
+            return jfrogCredentials;
         } catch (error: any) {
             throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,7 +83,7 @@ export class Utils {
         }
 
         // Used for usage reporting
-        this.exportVariableIfNotSet("JFROG_CLI_OIDC_CONFIG","TRUE")
+        this.exportVariableIfNotSet("JFROG_CLI_USAGE_CONFIG_OIDC","TRUE")
         if (!jfrogCredentials.jfrogUrl) {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export class Utils {
     // OpenID Connect audience input
     private static readonly OIDC_AUDIENCE_ARG: string = 'oidc-audience';
     // OpenID Connect provider_name input
-    private static readonly OIDC_INTEGRATION_PROVIDER_NAME: string = 'oidc-provider-name';
+    static readonly OIDC_INTEGRATION_PROVIDER_NAME: string = 'oidc-provider-name';
     // Disable Job Summaries feature flag
     public static readonly JOB_SUMMARY_DISABLE: string = 'disable-job-summary';
     // Disable auto build info publish feature flag
@@ -82,6 +82,8 @@ export class Utils {
             return jfrogCredentials;
         }
 
+        // Used for usage reporting
+        this.exportVariableIfNotSet("JFROG_CLI_OIDC_CONFIG","TRUE")
         if (!jfrogCredentials.jfrogUrl) {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,8 +98,7 @@ export class Utils {
         try {
             jfrogCredentials = await this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName);
             // Set environment variable to track OIDC logins in the usage report.
-            core.exportVariable('JFROG_CLI_USAGE_BUILD_PUBLISHED_AUTO', 'TRUE');
-            this.exportVariableIfNotSet('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
+            core.exportVariable('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
             return jfrogCredentials;
         } catch (error: any) {
             throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Add the following commands to usage:
`config_oidc`
`config`
`rt_build_publish_auto`

This is done here by exporting the env vars