### PR TITLE
Add Moving Minor Version Tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Update v4 tag
-        run: git tag -f v4
+      - name: Update v4 tags
+        run: |
+          git tag -f v4
+          git tag -f v4.4
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
MAJOR version tag is available for reference but when referenced can result in unexpected changes in behaviors downstream. Adding Minor version tag to reference allows for more stable dynamic resolving of action's updates.