### PR TITLE
New OIDC fields added, including the GitHub job name and run ID

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,13 +125,17 @@ class Utils {
             const exchangeUrl = jfrogCredentials.jfrogUrl.replace(/\/$/, '') + '/access/api/v1/oidc/token';
             core.debug('Exchanging GitHub JSON web token with a JFrog access token...');
             let projectKey = process.env.JF_PROJECT || '';
+            let jobId = process.env.GITHUB_JOB || '';
+            let runId = process.env.GITHUB_RUN_ID || '';
             const httpClient = new http_client_1.HttpClient();
             const data = `{
             "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
             "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
             "subject_token": "${jsonWebToken}",
             "provider_name": "${oidcProviderName}",
-            "project_key": "${projectKey}"
+            "project_key": "${projectKey}",
+            "gh_job_id": "${jobId}",
+            "gh_run_id": "${runId}"
         }`;
             const additionalHeaders = {
                 'Content-Type': 'application/json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.4.2",
+    "version": "4.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.4.2",
+    "version": "4.4.3",
     "private": true,
     "description": "Setup JFrog CLI in GitHub Actions",
     "main": "lib/main.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,8 @@ export class Utils {
             "subject_token": "${jsonWebToken}",
             "provider_name": "${oidcProviderName}",
             "project_key": "${projectKey}",
+            "gh_job_id": "${jobId}",
+            "gh_run_id": "${runId}"
         }`;
 
         const additionalHeaders: OutgoingHttpHeaders = {


### PR DESCRIPTION
Add new fields to the OIDC token exchange.

`gh_job_id`- The [job_id](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id) of the current job. For example, greeting_job.
`gh_run_id` - A unique number for each workflow run within a repository. This number does not change if you re-run the workflow run. For example, 1658821493.
