### PR TITLE
Fix JFrog servers configurations cleanup

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -340,12 +340,13 @@ class Utils {
         return serverId;
     }
     /**
-     * Return custom server ID if provided, or default server ID otherwise.
+     * Returns the custom server ID if provided, otherwise returns the default server ID.
      */
     static getCustomOrDefaultServerId() {
-        let customServerId = core.getInput(Utils.CUSTOM_SERVER_ID);
-        if (customServerId) {
-            return customServerId;
+        let inputtedCustomServerId = core.getInput(Utils.CUSTOM_SERVER_ID);
+        if (inputtedCustomServerId != '') {
+            this.customServerId = inputtedCustomServerId;
+            return this.customServerId;
         }
         return Utils.getRunDefaultServerId();
     }
@@ -407,15 +408,24 @@ class Utils {
         });
     }
     /**
-     * Removed configured JFrog CLI servers that are saved in the servers env var, and unset the env var.
+     * Removes configured JFrog CLI servers saved in the environment variable.
+     * If a custom server ID is defined, only remove the custom server ID.
      */
     static removeJFrogServers() {
         return __awaiter(this, void 0, void 0, function* () {
-            for (const serverId of Utils.getConfiguredJFrogServers()) {
-                core.debug(`Removing server ID: '${serverId}'...`);
-                yield Utils.runCli(['c', 'rm', serverId, '--quiet']);
+            if (this.customServerId) {
+                // Remove only the custom server ID
+                core.debug(`Removing server ID: '${this.customServerId}'...`);
+                yield Utils.runCli(['c', 'rm', this.customServerId, '--quiet']);
             }
-            core.exportVariable(Utils.JFROG_CLI_SERVER_IDS_ENV_VAR, '');
+            else {
+                // Remove all configured server IDs
+                for (const serverId of Utils.getConfiguredJFrogServers()) {
+                    core.debug(`Removing server ID: '${serverId}'...`);
+                    yield Utils.runCli(['c', 'rm', serverId, '--quiet']);
+                }
+                core.exportVariable(Utils.JFROG_CLI_SERVER_IDS_ENV_VAR, '');
+            }
         });
     }
     /**
@@ -755,7 +765,6 @@ class Utils {
         return tempDir;
     }
 }
-exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 // Default artifactory URL and repository for downloading JFrog CLI
@@ -809,3 +818,6 @@ Utils.CUSTOM_SERVER_ID = 'custom-server-id';
 // It cannot be linked to the repository, as GitHub serves the image from a CDN,
 // which gets blocked by the browser, resulting in an empty image.
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
+// Optional custom server ID defined by the user
+Utils.customServerId = undefined;
+exports.Utils = Utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -345,9 +345,12 @@ class Utils {
     static getCustomOrDefaultServerId() {
         let inputtedCustomServerId = core.getInput(Utils.CUSTOM_SERVER_ID);
         if (inputtedCustomServerId != '') {
+            core.info(`Using custom server ID: '${inputtedCustomServerId}'`);
             this.customServerId = inputtedCustomServerId;
             return this.customServerId;
         }
+        core.info(`Using default server ID: '${Utils.getRunDefaultServerId()}'`);
+        core.info(`the value of custom is: '${this.customServerId}'`);
         return Utils.getRunDefaultServerId();
     }
     /**
@@ -413,9 +416,10 @@ class Utils {
      */
     static removeJFrogServers() {
         return __awaiter(this, void 0, void 0, function* () {
+            core.info("the value of custom is: '" + this.customServerId + "'");
             if (this.customServerId) {
                 // Remove only the custom server ID
-                core.debug(`Removing server ID: '${this.customServerId}'...`);
+                core.debug(`Removing custom server ID: '${this.customServerId}'...`);
                 yield Utils.runCli(['c', 'rm', this.customServerId, '--quiet']);
             }
             else {
@@ -765,7 +769,6 @@ class Utils {
         return tempDir;
     }
 }
-exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 // Default artifactory URL and repository for downloading JFrog CLI
@@ -821,3 +824,4 @@ Utils.CUSTOM_SERVER_ID = 'custom-server-id';
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
 // Optional custom server ID defined by the user
 Utils.customServerId = undefined;
+exports.Utils = Utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -765,6 +765,7 @@ class Utils {
         return tempDir;
     }
 }
+exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 // Default artifactory URL and repository for downloading JFrog CLI
@@ -820,4 +821,3 @@ Utils.CUSTOM_SERVER_ID = 'custom-server-id';
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
 // Optional custom server ID defined by the user
 Utils.customServerId = undefined;
-exports.Utils = Utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -343,15 +343,15 @@ class Utils {
      * Returns the custom server ID if provided, otherwise returns the default server ID.
      */
     static getCustomOrDefaultServerId() {
-        let inputtedCustomServerId = core.getInput(Utils.CUSTOM_SERVER_ID);
-        if (inputtedCustomServerId != '') {
-            core.info(`Using custom server ID: '${inputtedCustomServerId}'`);
-            this.customServerId = inputtedCustomServerId;
-            return this.customServerId;
+        const customServerId = this.getInputtedCustomId();
+        return customServerId || this.getRunDefaultServerId();
+    }
+    static getInputtedCustomId() {
+        let customServerId = core.getInput(Utils.CUSTOM_SERVER_ID);
+        if (customServerId) {
+            return customServerId;
         }
-        core.info(`Using default server ID: '${Utils.getRunDefaultServerId()}'`);
-        core.info(`the value of custom is: '${this.customServerId}'`);
-        return Utils.getRunDefaultServerId();
+        return undefined;
     }
     /**
      * Return the default server ID for JFrog CLI server configuration.
@@ -416,11 +416,12 @@ class Utils {
      */
     static removeJFrogServers() {
         return __awaiter(this, void 0, void 0, function* () {
-            core.info("the value of custom is: '" + this.customServerId + "'");
-            if (this.customServerId) {
+            const customServerId = this.getInputtedCustomId();
+            core.info(`The value of custom is: '${customServerId}'`);
+            if (customServerId) {
                 // Remove only the custom server ID
-                core.debug(`Removing custom server ID: '${this.customServerId}'...`);
-                yield Utils.runCli(['c', 'rm', this.customServerId, '--quiet']);
+                core.debug(`Removing custom server ID: '${customServerId}'...`);
+                yield Utils.runCli(['c', 'rm', customServerId, '--quiet']);
             }
             else {
                 // Remove all configured server IDs
@@ -769,7 +770,6 @@ class Utils {
         return tempDir;
     }
 }
-exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 // Default artifactory URL and repository for downloading JFrog CLI
@@ -823,5 +823,4 @@ Utils.CUSTOM_SERVER_ID = 'custom-server-id';
 // It cannot be linked to the repository, as GitHub serves the image from a CDN,
 // which gets blocked by the browser, resulting in an empty image.
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
-// Optional custom server ID defined by the user
-Utils.customServerId = undefined;
+exports.Utils = Utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -770,6 +770,7 @@ class Utils {
         return tempDir;
     }
 }
+exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 // Default artifactory URL and repository for downloading JFrog CLI
@@ -823,4 +824,3 @@ Utils.CUSTOM_SERVER_ID = 'custom-server-id';
 // It cannot be linked to the repository, as GitHub serves the image from a CDN,
 // which gets blocked by the browser, resulting in an empty image.
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
-exports.Utils = Utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -769,6 +769,7 @@ class Utils {
         return tempDir;
     }
 }
+exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 Utils.USER_AGENT = 'setup-jfrog-cli-github-action/' + require('../package.json').version;
 // Default artifactory URL and repository for downloading JFrog CLI
@@ -824,4 +825,3 @@ Utils.CUSTOM_SERVER_ID = 'custom-server-id';
 Utils.MARKDOWN_HEADER_PNG_URL = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
 // Optional custom server ID defined by the user
 Utils.customServerId = undefined;
-exports.Utils = Utils;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,8 +71,6 @@ export class Utils {
     // which gets blocked by the browser, resulting in an empty image.
     private static MARKDOWN_HEADER_PNG_URL: string = 'https://media.jfrog.com/wp-content/uploads/2024/09/02161430/jfrog-job-summary.svg';
     private static isSummaryHeaderAccessible: boolean;
-    // Optional custom server ID defined by the user
-    private static customServerId: string | undefined = undefined;
 
     /**
      * Retrieves server credentials for accessing JFrog's server
@@ -392,15 +390,16 @@ export class Utils {
      * Returns the custom server ID if provided, otherwise returns the default server ID.
      */
     private static getCustomOrDefaultServerId(): string {
-        let inputtedCustomServerId: string = core.getInput(Utils.CUSTOM_SERVER_ID);
-        if (inputtedCustomServerId != '') {
-            core.info(`Using custom server ID: '${inputtedCustomServerId}'`);
-            this.customServerId = inputtedCustomServerId;
-            return this.customServerId;
+        const customServerId :string | undefined = this.getInputtedCustomId();
+        return customServerId || this.getRunDefaultServerId();
+    }
+
+    private static getInputtedCustomId(): string | undefined {
+        let customServerId: string = core.getInput(Utils.CUSTOM_SERVER_ID);
+        if (customServerId) {
+            return customServerId;
         }
-        core.info(`Using default server ID: '${Utils.getRunDefaultServerId()}'`);
-        core.info(`the value of custom is: '${ this.customServerId}'`);
-        return Utils.getRunDefaultServerId();
+        return undefined
     }
 
     /**
@@ -477,11 +476,13 @@ export class Utils {
      * If a custom server ID is defined, only remove the custom server ID.
      */
     public static async removeJFrogServers() {
-        core.info("the value of custom is: '" + this.customServerId + "'");
-        if (this.customServerId) {
+        const customServerId:string | undefined = this.getInputtedCustomId();
+        core.info(`The value of custom is: '${customServerId}'`);
+
+        if (customServerId) {
             // Remove only the custom server ID
-            core.debug(`Removing custom server ID: '${this.customServerId}'...`);
-            await Utils.runCli(['c', 'rm', this.customServerId, '--quiet']);
+            core.debug(`Removing custom server ID: '${customServerId}'...`);
+            await Utils.runCli(['c', 'rm', customServerId, '--quiet']);
         } else {
             // Remove all configured server IDs
             for (const serverId of Utils.getConfiguredJFrogServers()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -390,7 +390,7 @@ export class Utils {
      * Returns the custom server ID if provided, otherwise returns the default server ID.
      */
     private static getCustomOrDefaultServerId(): string {
-        const customServerId :string | undefined = this.getInputtedCustomId();
+        const customServerId: string | undefined = this.getInputtedCustomId();
         return customServerId || this.getRunDefaultServerId();
     }
 
@@ -399,7 +399,7 @@ export class Utils {
         if (customServerId) {
             return customServerId;
         }
-        return undefined
+        return undefined;
     }
 
     /**
@@ -476,7 +476,7 @@ export class Utils {
      * If a custom server ID is defined, only remove the custom server ID.
      */
     public static async removeJFrogServers() {
-        const customServerId:string | undefined = this.getInputtedCustomId();
+        const customServerId: string | undefined = this.getInputtedCustomId();
         core.info(`The value of custom is: '${customServerId}'`);
 
         if (customServerId) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -394,9 +394,12 @@ export class Utils {
     private static getCustomOrDefaultServerId(): string {
         let inputtedCustomServerId: string = core.getInput(Utils.CUSTOM_SERVER_ID);
         if (inputtedCustomServerId != '') {
+            core.info(`Using custom server ID: '${inputtedCustomServerId}'`);
             this.customServerId = inputtedCustomServerId;
             return this.customServerId;
         }
+        core.info(`Using default server ID: '${Utils.getRunDefaultServerId()}'`);
+        core.info(`the value of custom is: '${ this.customServerId}'`);
         return Utils.getRunDefaultServerId();
     }
 
@@ -474,9 +477,10 @@ export class Utils {
      * If a custom server ID is defined, only remove the custom server ID.
      */
     public static async removeJFrogServers() {
+        core.info("the value of custom is: '" + this.customServerId + "'");
         if (this.customServerId) {
             // Remove only the custom server ID
-            core.debug(`Removing server ID: '${this.customServerId}'...`);
+            core.debug(`Removing custom server ID: '${this.customServerId}'...`);
             await Utils.runCli(['c', 'rm', this.customServerId, '--quiet']);
         } else {
             // Remove all configured server IDs


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

**PR Description:**  

This PR updates the JFrog server cleanup function to improve its behavior in certain scenarios:  

- When a custom server ID is set, the cleanup will only remove the configuration for that specific server.  
- If no custom server ID is specified, the cleanup will remove all configured servers.  

This change addresses cases where multiple `setup-jfrog-cli` jobs are executed by the same agent, potentially causing server configurations to be deleted while they are still in use by other tasks. To avoid this issue, it is recommended to use a custom server ID.  

---