### PR TITLE
Update README.md to include self-signed certificates information for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ Example step utilizing OpenID Connect:
 
 **Notice:** When using OIDC authentication, this action outputs both the OIDC token and the OIDC token username. These can be utilized within the current workflow to log into the JFrog platform through other actions or clients (e.g., for use with `docker login`). The added outputs are `oidc-token` and `oidc-user`, respectively.
 
+### Handling Self-Signed Certificates
+
+If your JFrog instance is configured with a self-signed SSL certificate, you may encounter errors with the GitHub Actions HTTP client not trusting your certificate. To help Node.js recognize and trust your self-signed certificate, follow these steps:
+
+1. **Prepare the SSL Certificate**: Save your SSL certificate chain, including the root CA and any intermediate certificates, into a `.pem` file. Ensure that this file is accessible within your GitHub Actions environment.
+
+2. **Set the Environment Variable**: In your GitHub Actions workflow, set the `NODE_EXTRA_CA_CERTS` environment variable to specify the location of your `.pem` file. Add the following line to your workflow:
+
+   ```yaml
+   env:
+       NODE_EXTRA_CA_CERTS: /path/to/certificate/server.pem
+   ```
+Replace /path/to/certificate/server.pem with the actual path to your certificate file on your runner.
+
 </details>
 
 <details>


### PR DESCRIPTION
…OIDC

Artifactory uses the GitHub Actions' built-in HTTP client to download the JFrog CLI and perform authentication with JFrog Access for OpenID Connect (OIDC). 

When an Artifactory instance is using self-signed certificates, you may run into the following error: 

Error: Exchanging JSON web token with an access token failed: self-signed certificate in certificate chain

This error occur can occur when trying to download the jfrog cli or exchange a token for OIDC.

To resolve this we need to add the certificates to the NODE_EXTRA_CA_CERTS environmental variable.

- Added a section explaining the use of self-signed certificates with OIDC/Github actions.
- Provided guidance on how to configure self-signed certificates in the context of OIDC.

- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
