### PR TITLE
Fix OIDC tests

### DIFF
--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -67,6 +67,8 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           oidc-provider-name: ${{ env.OIDC_PROVIDER_NAME }}
+          # Use the latest version before the new OIDC feature
+          version: '2.74.1'
 
       - name: Test JFrog CLI
         run: |


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Enforces old OIDC tests to use the old OIDC auth flow by setting the CLI version to 2.74.1 , which is the last version before the new OIDC feature was introduces