### PR TITLE
OIDC Authentication Flow Support

### DIFF
--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -1,0 +1,45 @@
+# This action is an integration test for OIDC workflow
+name: CLI OpenID Connect Test
+on:
+  push:
+    branches:
+      - master
+
+  # Triggers the workflow on labeled PRs only.
+  pull_request_target:
+    types: [ labeled ]
+
+
+# Ensures that only the latest commit is running for each PR at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  id-token: write
+jobs:
+  OIDC-Test:
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
+    name: OIDC-Access integration test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu, windows, macos ]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref:
+            ${{ github.event.pull_request.head.ref || github.sha }}
+
+      - name: Setup JFrog CLI
+        id: setup-jfrog-cli
+        uses: ./
+        env:
+          JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
+        with:
+          oidc-provider-name: setup-jfrog-cli-test
+
+      - name: Test JFrog CLI
+        run: |
+          jf rt ping

--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - "**"
 
   # Triggers the workflow on labeled PRs only.
   pull_request_target:

--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - "**"
 
   # Triggers the workflow on labeled PRs only.
   pull_request_target:

--- a/.github/workflows/manual-oidc-test.yml
+++ b/.github/workflows/manual-oidc-test.yml
@@ -4,8 +4,7 @@ name: Manual OpenID Exchange Connect Test
 on:
   push:
     branches:
-#      - master
-      - "**"
+      - master
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]

--- a/.github/workflows/manual-oidc-test.yml
+++ b/.github/workflows/manual-oidc-test.yml
@@ -1,5 +1,6 @@
 # This action is an integration test for OIDC workflow
-name: OpenID Connect Test
+# Which uses the manual approach for backwards compliantly
+name: Manual OpenID Exchange Connect Test
 on:
   push:
     branches:

--- a/.github/workflows/manual-oidc-test.yml
+++ b/.github/workflows/manual-oidc-test.yml
@@ -4,7 +4,8 @@ name: Manual OpenID Exchange Connect Test
 on:
   push:
     branches:
-      - master
+#      - master
+      - "**"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]

--- a/.github/workflows/manual-oidc-test.yml
+++ b/.github/workflows/manual-oidc-test.yml
@@ -70,6 +70,8 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           oidc-provider-name: ${{ env.OIDC_PROVIDER_NAME }}
+          # The last version which outputs OIDC params as step outputs
+          version: '2.74.1'
 
       - name: Test JFrog CLI
         run: |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,21 @@ Example step utilizing OpenID Connect:
       oidc-provider-name: setup-jfrog-cli
 ```
 
-**Notice:** When using OIDC authentication, this action outputs both the OIDC token and the OIDC token username. These can be utilized within the current workflow to log into the JFrog platform through other actions or clients (e.g., for use with `docker login`). The added outputs are `oidc-token` and `oidc-user`, respectively.
+**Notice:**
+
+Depending on the version of the CLI and how it is provisioned, this action intelligently chooses the optimal OIDC authentication flow:
+
+✅ Native OIDC (Recommended Path)
+
+If you are using JFrog CLI version 2.75.0 or above and not downloading the CLI from Artifactory
+(via the download-repository input),
+the setup action will use the CLI's native `--oidc-token-id` authentication mechanism.
+
+🔁 Manual Fallback (for legacy or remote setups)
+
+If the CLI version is below 2.75.0, or if you're downloading the CLI from Artifactory using download-repository, the action will automatically fall back to a manual OIDC token exchange using the JFrog Platform REST API.
+
+📝 This fallback logic is kept for backward compatibility but is planned for deprecation to avoid maintaining duplicate authentication flows.
 
 ### Handling Self-Signed Certificates
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "JFrog"
 inputs:
     version:
         description: "JFrog CLI Version"
-        default: "2.73.0"
+        default: "2.75.0"
         required: false
     download-repository:
         description: "Remote repository in Artifactory pointing to 'https://releases.jfrog.io/artifactory/jfrog-cli'. Use this parameter in case you don't have an Internet access."

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -831,9 +831,11 @@ class Utils {
             // Version should be more than min version
             // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
             if ((version === Utils.LATEST_CLI_VERSION || (0, semver_1.gte)(version, Utils.MIN_CLI_OIDC_VERSION)) && !core.getInput(this.CLI_REMOTE_ARG)) {
+                core.debug('Using CLI Config OIDC Auth Method..');
                 return this.setOidcTokenID(jfrogCredentials);
             }
             // Fallback to manual OIDC exchange for backward compatibility
+            core.debug('Using Manual OIDC Auth Method..');
             return this.manualOIDCExchange(jfrogCredentials);
         });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,103 +51,18 @@ class Utils {
     /**
      * Retrieves server credentials for accessing JFrog's server
      * searching for existing environment variables such as JF_ACCESS_TOKEN or the combination of JF_USER and JF_PASSWORD.
-     * If the 'oidc-provider-name' argument was provided, it generates an access token for the specified JFrog's server using the OpenID Connect mechanism.
+     * If the 'oidc-provider-name' argument was provided, it will use OIDC auth.
      * @returns JfrogCredentials struct filled with collected credentials
      */
     static getJfrogCredentials() {
         return __awaiter(this, void 0, void 0, function* () {
+            var _a;
             let jfrogCredentials = this.collectJfrogCredentialsFromEnvVars();
-            const oidcProviderName = core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME);
-            if (!oidcProviderName) {
-                // Set environment variable to track OIDC usage.
-                core.exportVariable('JFROG_CLI_USAGE_CONFIG_OIDC', '');
-                core.exportVariable('JFROG_CLI_USAGE_OIDC_USED', 'FALSE');
-                // Use JF_ENV or the credentials found in the environment variables
-                return jfrogCredentials;
+            jfrogCredentials.oidcProviderName = (_a = core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME)) === null || _a === void 0 ? void 0 : _a.trim();
+            if (jfrogCredentials.oidcProviderName) {
+                return this.handleOidcAuth(jfrogCredentials);
             }
-            if (!jfrogCredentials.jfrogUrl) {
-                throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
-            }
-            core.info('Obtaining an access token through OpenID Connect...');
-            const audience = core.getInput(Utils.OIDC_AUDIENCE_ARG);
-            let jsonWebToken;
-            try {
-                core.debug('Fetching JSON web token');
-                jsonWebToken = yield core.getIDToken(audience);
-            }
-            catch (error) {
-                throw new Error(`Getting openID Connect JSON web token failed: ${error.message}`);
-            }
-            const applicationKey = yield this.getApplicationKey();
-            try {
-                jfrogCredentials = yield this.getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName, applicationKey);
-                // Set environment variable to track OIDC usage.
-                core.exportVariable('JFROG_CLI_USAGE_CONFIG_OIDC', 'TRUE');
-                core.exportVariable('JFROG_CLI_USAGE_OIDC_USED', 'TRUE');
-                return jfrogCredentials;
-            }
-            catch (error) {
-                throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);
-            }
-        });
-    }
-    /**
-     * Retrieves the application key from .jfrog/config file.
-     *
-     * This method attempts to read config file from the file system.
-     * If the configuration file exists and contains the application key, it returns the key.
-     * If the configuration file does not exist or does not contain the application key, it returns an empty string.
-     *
-     * @returns A promise that resolves to the application key as a string.
-     */
-    static getApplicationKey() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const configFilePath = path.join(this.JF_CONFIG_DIR_NAME, this.JF_CONFIG_FILE_NAME);
-            try {
-                const config = yield this.readConfigFromFileSystem(configFilePath);
-                if (!config) {
-                    console.debug('Config file is empty or not found.');
-                    return '';
-                }
-                const configObj = (0, js_yaml_1.load)(config);
-                const application = configObj[this.APPLICATION_ROOT_YML];
-                if (!application) {
-                    console.log('Application root is not found in the config file.');
-                    return '';
-                }
-                const applicationKey = application[this.KEY];
-                if (!applicationKey) {
-                    console.log('Application key is not found in the config file.');
-                    return '';
-                }
-                console.debug('Found application key: ' + applicationKey);
-                return applicationKey;
-            }
-            catch (error) {
-                console.error('Error reading config:', error);
-                return '';
-            }
-        });
-    }
-    /**
-     * Reads .jfrog configuration file from file system.
-     *
-     * This method attempts to read .jfrog configuration file from the specified relative path.
-     * If the file exists, it reads the file content and returns it as a string.
-     * If the file does not exist, it returns an empty string.
-     *
-     * @param configRelativePath - The relative path to the configuration file.
-     * @returns A promise that resolves to the content of the configuration file as a string.
-     */
-    static readConfigFromFileSystem(configRelativePath) {
-        return __awaiter(this, void 0, void 0, function* () {
-            core.debug(`Reading config from file system. Looking for ${configRelativePath}`);
-            if (!(0, fs_1.existsSync)(configRelativePath)) {
-                core.debug(`config.yml not found in ${configRelativePath}`);
-                return '';
-            }
-            core.debug(`config.yml found in ${configRelativePath}`);
-            return yield fs_1.promises.readFile(configRelativePath, 'utf-8');
+            return jfrogCredentials;
         });
     }
     /**
@@ -161,6 +76,9 @@ class Utils {
             accessToken: process.env.JF_ACCESS_TOKEN,
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
+            oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG),
+            oidcTokenId: '',
         };
         if (jfrogCredentials.password && !jfrogCredentials.username) {
             throw new Error('JF_PASSWORD is configured, but the JF_USER environment variable was not set.');
@@ -175,17 +93,18 @@ class Utils {
         if (jfrogCredentials.password) {
             core.setSecret(jfrogCredentials.password);
         }
+        // TODO implement
+        //Utils.validateInputsConstraints(jfrogCredentials);
         return jfrogCredentials;
     }
     /**
      * Exchanges GitHub JWT with a valid JFrog access token
      * @param jfrogCredentials existing JFrog credentials - url, access token, username + password
      * @param jsonWebToken JWT achieved from GitHub JWT provider
-     * @param oidcProviderName OIDC provider name
      * @param applicationKey
      * @returns an access token for the requested Artifactory server
      */
-    static getJfrogAccessTokenThroughOidcProtocol(jfrogCredentials, jsonWebToken, oidcProviderName, applicationKey) {
+    static exchangeOidcAndSetAsAccessToken(jfrogCredentials, jsonWebToken, applicationKey) {
         return __awaiter(this, void 0, void 0, function* () {
             // If we've reached this stage, the jfrogCredentials.jfrogUrl field should hold a non-empty value obtained from process.env.JF_URL
             const exchangeUrl = jfrogCredentials.jfrogUrl.replace(/\/$/, '') + '/access/api/v1/oidc/token';
@@ -199,7 +118,7 @@ class Utils {
             "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
             "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
             "subject_token": "${jsonWebToken}",
-            "provider_name": "${oidcProviderName}",
+            "provider_name": "${jfrogCredentials.oidcProviderName}",
             "project_key": "${projectKey}",
             "gh_job_id": "${jobId}",
             "gh_run_id": "${runId}",
@@ -375,21 +294,39 @@ class Utils {
      */
     static getSeparateEnvConfigArgs(jfrogCredentials) {
         /**
-         * @name url - JFrog Platform URL
-         * @name user&password - JFrog Platform basic authentication
-         * @name accessToken - Jfrog Platform access token
+          * @name url - JFrog Platform URL
+          * @name  user&password - JFrog Platform basic authentication
+          * @name accessToken - Jfrog Platform access token
+          * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
+          * @name oidcAudience - JFrog Platform OpenID Connect audience
          */
         let url = jfrogCredentials.jfrogUrl;
         let user = jfrogCredentials.username;
         let password = jfrogCredentials.password;
         let accessToken = jfrogCredentials.accessToken;
+        let oidcProviderName = jfrogCredentials.oidcProviderName;
+        let oidcTokenId = jfrogCredentials.oidcTokenId;
         if (url) {
             let configCmd = [Utils.getServerIdForConfig(), '--url', url, '--interactive=false', '--overwrite=true'];
-            if (accessToken) {
-                configCmd.push('--access-token', accessToken);
-            }
-            else if (user && password) {
-                configCmd.push('--user', user, '--password', password);
+            switch (true) {
+                case !!oidcProviderName:
+                    configCmd.push(`--oidc-provider-name=${oidcProviderName}`);
+                    configCmd.push('--oidc-provider-type=Github');
+                    if (oidcTokenId) {
+                        configCmd.push(`--oidc-token-id=${oidcTokenId}`);
+                    }
+                    configCmd.push('--oidc-audience=jfrog-github');
+                    break;
+                case !!accessToken:
+                    if (accessToken) {
+                        configCmd.push('--access-token', accessToken);
+                    }
+                    break;
+                case !!user && !!password:
+                    if (user && password) {
+                        configCmd.push('--user', user, '--password', password);
+                    }
+                    break;
             }
             return configCmd;
         }
@@ -429,9 +366,13 @@ class Utils {
         return Utils.SETUP_JFROG_CLI_SERVER_ID;
     }
     static setCliEnv() {
+        var _a, _b, _c, _d;
         Utils.exportVariableIfNotSet('JFROG_CLI_ENV_EXCLUDE', '*password*;*secret*;*key*;*token*;*auth*;JF_ARTIFACTORY_*;JF_ENV_*;JF_URL;JF_USER;JF_PASSWORD;JF_ACCESS_TOKEN');
         Utils.exportVariableIfNotSet('JFROG_CLI_OFFER_CONFIG', 'false');
         Utils.exportVariableIfNotSet('CI', 'true');
+        Utils.exportVariableIfNotSet('JFROG_CLI_SOURCECODE_REPOSITORY', (_a = process.env.GITHUB_REPOSITORY) !== null && _a !== void 0 ? _a : '');
+        Utils.exportVariableIfNotSet('JFROG_CLI_CI_JOB_ID', (_b = process.env.GITHUB_WORKFLOW) !== null && _b !== void 0 ? _b : '');
+        Utils.exportVariableIfNotSet('JFROG_CLI_CI_RUN_ID', (_c = process.env.GITHUB_RUN_ID) !== null && _c !== void 0 ? _c : '');
         let buildNameEnv = process.env.GITHUB_WORKFLOW;
         if (buildNameEnv) {
             Utils.exportVariableIfNotSet('JFROG_CLI_BUILD_NAME', buildNameEnv);
@@ -451,19 +392,8 @@ class Utils {
         if (!core.getBooleanInput(Utils.JOB_SUMMARY_DISABLE)) {
             Utils.enableJobSummaries();
         }
-        Utils.setUsageEnvVars();
-    }
-    // Set usage variables to be captured by JFrog CLI visibility metric service.
-    static setUsageEnvVars() {
-        var _a, _b, _c;
-        // Set the GitHub repository name or default to an empty string.
-        core.exportVariable('JFROG_CLI_USAGE_GIT_REPO', (_a = process.env.GITHUB_REPOSITORY) !== null && _a !== void 0 ? _a : '');
-        // Set the GitHub workflow name or default to an empty string.
-        core.exportVariable('JFROG_CLI_USAGE_JOB_ID', (_b = process.env.GITHUB_WORKFLOW) !== null && _b !== void 0 ? _b : '');
-        // Set the GitHub run ID or default to an empty string.
-        core.exportVariable('JFROG_CLI_USAGE_RUN_ID', (_c = process.env.GITHUB_RUN_ID) !== null && _c !== void 0 ? _c : '');
-        // Indicate if JF_GIT_TOKEN is provided as an environment variable.
-        core.exportVariable('JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED', !!process.env.JF_GIT_TOKEN);
+        // Indicate if JF_GIT_TOKEN is provided as an environment variable, used by Xray usage.
+        Utils.exportVariableIfNotSet('JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED', (_d = process.env.JF_GIT_TOKEN) !== null && _d !== void 0 ? _d : '');
     }
     /**
      * Enabling job summary is done by setting the output dir for the summaries.
@@ -885,6 +815,135 @@ class Utils {
     static getGithubJobId() {
         return process.env.GITHUB_WORKFLOW || '';
     }
+    /*
+    Currently, OIDC authentication can be handled in two ways due to CLI version limitations:
+    1. Manually call the REST API from this codebase.
+    2. Use the new OIDC token ID feature in the CLI (2.75.0+).
+
+    To support backward compatibility, we retain the old manual code.
+    However, it should not be maintained and should be removed in the future.
+    */
+    static handleOidcAuth(jfrogCredentials) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const version = core.getInput(Utils.CLI_VERSION_ARG);
+            // Use CLI OIDC exchange if supported
+            if (version === Utils.LATEST_CLI_VERSION || (0, semver_1.gte)(version, Utils.MIN_CLI_OIDC_VERSION)) {
+                return this.setOidcTokenID(jfrogCredentials);
+            }
+            // Fallback to manual OIDC exchange for backward compatibility
+            return this.manualOIDCExchange(jfrogCredentials);
+        });
+    }
+    /*
+    This function manually exchanges oidc token and updates the cretials object with an access token retrived
+     */
+    static manualOIDCExchange(jfrogCredentials) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!jfrogCredentials.jfrogUrl) {
+                throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
+            }
+            // Get ID token from GitHub
+            core.info('Obtaining an access token through OpenID Connect...');
+            const audience = core.getInput(Utils.OIDC_AUDIENCE_ARG);
+            let jsonWebToken;
+            try {
+                core.debug('Fetching JSON web token');
+                jsonWebToken = yield core.getIDToken(audience);
+            }
+            catch (error) {
+                throw new Error(`Getting openID Connect JSON web token failed: ${error.message}`);
+            }
+            // Exchanges the token and set as access token in the credential's object
+            const applicationKey = yield this.getApplicationKey();
+            try {
+                return yield this.exchangeOidcAndSetAsAccessToken(jfrogCredentials, jsonWebToken, applicationKey);
+            }
+            catch (error) {
+                throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);
+            }
+        });
+    }
+    /**
+     * @param jfrogCredentials - The existing JFrog credentials
+     * @returns The updated JfrogCredentials with the OIDC tokenID
+     * @throws Error if JF_URL is not provided or if fetching the JSON web token fails
+     */
+    static setOidcTokenID(jfrogCredentials) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!jfrogCredentials.jfrogUrl) {
+                throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
+            }
+            core.info('Obtaining an access token through OpenID Connect...');
+            try {
+                core.debug('Fetching JSON web token');
+                jfrogCredentials.oidcTokenId = yield core.getIDToken(jfrogCredentials.oidcAudience);
+            }
+            catch (error) {
+                throw new Error(`Getting OpenID Connect JSON web token failed: ${error.message}`);
+            }
+            core.debug('Successfully obtained an access token through OpenID Connect');
+            return jfrogCredentials;
+        });
+    }
+    /**
+     * Retrieves the application key from .jfrog/config file.
+     *
+     * This method attempts to read config file from the file system.
+     * If the configuration file exists and contains the application key, it returns the key.
+     * If the configuration file does not exist or does not contain the application key, it returns an empty string.
+     *
+     * @returns A promise that resolves to the application key as a string.
+     */
+    static getApplicationKey() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const configFilePath = path.join(this.JF_CONFIG_DIR_NAME, this.JF_CONFIG_FILE_NAME);
+            try {
+                const config = yield this.readConfigFromFileSystem(configFilePath);
+                if (!config) {
+                    console.debug('Config file is empty or not found.');
+                    return '';
+                }
+                const configObj = (0, js_yaml_1.load)(config);
+                const application = configObj[this.APPLICATION_ROOT_YML];
+                if (!application) {
+                    console.log('Application root is not found in the config file.');
+                    return '';
+                }
+                const applicationKey = application[this.KEY];
+                if (!applicationKey) {
+                    console.log('Application key is not found in the config file.');
+                    return '';
+                }
+                console.debug('Found application key: ' + applicationKey);
+                return applicationKey;
+            }
+            catch (error) {
+                console.error('Error reading config:', error);
+                return '';
+            }
+        });
+    }
+    /**
+     * Reads .jfrog configuration file from file system.
+     *
+     * This method attempts to read .jfrog configuration file from the specified relative path.
+     * If the file exists, it reads the file content and returns it as a string.
+     * If the file does not exist, it returns an empty string.
+     *
+     * @param configRelativePath - The relative path to the configuration file.
+     * @returns A promise that resolves to the content of the configuration file as a string.
+     */
+    static readConfigFromFileSystem(configRelativePath) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Reading config from file system. Looking for ${configRelativePath}`);
+            if (!(0, fs_1.existsSync)(configRelativePath)) {
+                core.debug(`config.yml not found in ${configRelativePath}`);
+                return '';
+            }
+            core.debug(`config.yml found in ${configRelativePath}`);
+            return yield fs_1.promises.readFile(configRelativePath, 'utf-8');
+        });
+    }
 }
 exports.Utils = Utils;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -964,3 +1023,4 @@ Utils.SOURCE_PARAM_VALUE = '1';
 // Metric query parameter indicating the metric type
 Utils.METRIC_PARAM_KEY = 'm';
 Utils.METRIC_PARAM_VALUE = '1';
+Utils.MIN_CLI_OIDC_VERSION = '2.75.0';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -294,11 +294,11 @@ class Utils {
      */
     static getSeparateEnvConfigArgs(jfrogCredentials) {
         /**
-          * @name url - JFrog Platform URL
-          * @name  user&password - JFrog Platform basic authentication
-          * @name accessToken - Jfrog Platform access token
-          * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
-          * @name oidcAudience - JFrog Platform OpenID Connect audience
+         * @name url - JFrog Platform URL
+         * @name  user&password - JFrog Platform basic authentication
+         * @name accessToken - Jfrog Platform access token
+         * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
+         * @name oidcAudience - JFrog Platform OpenID Connect audience
          */
         let url = jfrogCredentials.jfrogUrl;
         let user = jfrogCredentials.username;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -293,7 +293,8 @@ class Utils {
     static getSeparateEnvConfigArgs(jfrogCredentials) {
         /**
          * @name url - JFrog Platform URL
-         * @name  user&password - JFrog Platform basic authentication
+         * @name user - JFrog Platform basic authentication
+         * @name password - JFrog Platform basic authentication
          * @name accessToken - Jfrog Platform access token
          * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
          * @name oidcAudience - JFrog Platform OpenID Connect audience
@@ -305,30 +306,27 @@ class Utils {
         let oidcProviderName = jfrogCredentials.oidcProviderName;
         let oidcTokenId = jfrogCredentials.oidcTokenId;
         let oidcAudience = jfrogCredentials.oidcAudience;
-        if (url) {
-            let configCmd = [Utils.getServerIdForConfig(), '--url', url, '--interactive=false', '--overwrite=true'];
-            switch (true) {
-                case !!oidcProviderName:
-                    configCmd.push(`--oidc-provider-name=${oidcProviderName}`);
-                    configCmd.push('--oidc-provider-type=Github');
-                    if (oidcTokenId) {
-                        configCmd.push(`--oidc-token-id=${oidcTokenId}`);
-                    }
-                    configCmd.push(`--oidc-audience=${oidcAudience}`);
-                    break;
-                case !!accessToken:
-                    if (accessToken) {
-                        configCmd.push('--access-token', accessToken);
-                    }
-                    break;
-                case !!user && !!password:
-                    if (user && password) {
-                        configCmd.push('--user', user, '--password', password);
-                    }
-                    break;
-            }
-            return configCmd;
+        // Url is mandatory for JFrog CLI configuration
+        if (!url) {
+            return;
         }
+        const configCmd = [Utils.getServerIdForConfig(), '--url', url, '--interactive=false', '--overwrite=true'];
+        // OIDC auth
+        if (oidcProviderName) {
+            configCmd.push(`--oidc-provider-name=${oidcProviderName}`);
+            configCmd.push('--oidc-provider-type=Github');
+            configCmd.push(`--oidc-token-id=${oidcTokenId}`);
+            configCmd.push(`--oidc-audience=${oidcAudience}`);
+        }
+        // Access Token auth
+        if (accessToken) {
+            configCmd.push('--access-token', accessToken);
+        }
+        // Basic Auth
+        if (user && password) {
+            configCmd.push('--user', user, '--password', password);
+        }
+        return configCmd;
     }
     /**
      * Get server ID for JFrog CLI configuration. Save the server ID in the servers env var if it doesn't already exist.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -317,13 +317,13 @@ class Utils {
             configCmd.push('--oidc-provider-type=Github');
             configCmd.push(`--oidc-token-id=${oidcTokenId}`);
             configCmd.push(`--oidc-audience=${oidcAudience}`);
+            // Access Token
         }
-        // Access Token auth
-        if (accessToken) {
+        else if (!!accessToken) {
             configCmd.push('--access-token', accessToken);
+            // Basic Auth
         }
-        // Basic Auth
-        if (user && password) {
+        else if (!!user && !!password) {
             configCmd.push('--user', user, '--password', password);
         }
         return configCmd;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,7 +77,7 @@ class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG),
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || Utils.DEFAULT_OIDC_AUDIENCE,
             oidcTokenId: '',
         };
         if (jfrogCredentials.password && !jfrogCredentials.username) {
@@ -93,8 +93,6 @@ class Utils {
         if (jfrogCredentials.password) {
             core.setSecret(jfrogCredentials.password);
         }
-        // TODO implement
-        //Utils.validateInputsConstraints(jfrogCredentials);
         return jfrogCredentials;
     }
     /**
@@ -306,6 +304,7 @@ class Utils {
         let accessToken = jfrogCredentials.accessToken;
         let oidcProviderName = jfrogCredentials.oidcProviderName;
         let oidcTokenId = jfrogCredentials.oidcTokenId;
+        let oidcAudience = jfrogCredentials.oidcAudience;
         if (url) {
             let configCmd = [Utils.getServerIdForConfig(), '--url', url, '--interactive=false', '--overwrite=true'];
             switch (true) {
@@ -315,7 +314,7 @@ class Utils {
                     if (oidcTokenId) {
                         configCmd.push(`--oidc-token-id=${oidcTokenId}`);
                     }
-                    configCmd.push('--oidc-audience=jfrog-github');
+                    configCmd.push(`--oidc-audience=${oidcAudience || Utils.DEFAULT_OIDC_AUDIENCE}`);
                     break;
                 case !!accessToken:
                     if (accessToken) {
@@ -820,14 +819,18 @@ class Utils {
     1. Manually call the REST API from this codebase.
     2. Use the new OIDC token ID feature in the CLI (2.75.0+).
 
-    To support backward compatibility, we retain the old manual code.
-    However, it should not be maintained and should be removed in the future.
+    If the CLI version supports it and the user is not using an artifactory download repository,
+    we use the new CLI native OIDC token ID flow.
+    Otherwise, we fall back to manual OIDC exchange for compatibility.
+
+    Note: The manual logic should be deprecated and removed once CLI remote supports native OIDC.
     */
     static handleOidcAuth(jfrogCredentials) {
         return __awaiter(this, void 0, void 0, function* () {
             const version = core.getInput(Utils.CLI_VERSION_ARG);
-            // Use CLI OIDC exchange if supported
-            if (version === Utils.LATEST_CLI_VERSION || (0, semver_1.gte)(version, Utils.MIN_CLI_OIDC_VERSION)) {
+            // Version should be more than min version
+            // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
+            if ((version === Utils.LATEST_CLI_VERSION || (0, semver_1.gte)(version, Utils.MIN_CLI_OIDC_VERSION)) && !core.getInput(this.CLI_REMOTE_ARG)) {
                 return this.setOidcTokenID(jfrogCredentials);
             }
             // Fallback to manual OIDC exchange for backward compatibility
@@ -835,7 +838,7 @@ class Utils {
         });
     }
     /*
-    This function manually exchanges oidc token and updates the cretials object with an access token retrived
+    This function manually exchanges oidc token and updates the credentials object with an access token retrieved
      */
     static manualOIDCExchange(jfrogCredentials) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -1024,3 +1027,4 @@ Utils.SOURCE_PARAM_VALUE = '1';
 Utils.METRIC_PARAM_KEY = 'm';
 Utils.METRIC_PARAM_VALUE = '1';
 Utils.MIN_CLI_OIDC_VERSION = '2.75.0';
+Utils.DEFAULT_OIDC_AUDIENCE = 'jfrog-github';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -314,7 +314,7 @@ class Utils {
                     if (oidcTokenId) {
                         configCmd.push(`--oidc-token-id=${oidcTokenId}`);
                     }
-                    configCmd.push(`--oidc-audience=${oidcAudience || Utils.DEFAULT_OIDC_AUDIENCE}`);
+                    configCmd.push(`--oidc-audience=${oidcAudience}`);
                     break;
                 case !!accessToken:
                     if (accessToken) {
@@ -827,12 +827,16 @@ class Utils {
     */
     static handleOidcAuth(jfrogCredentials) {
         return __awaiter(this, void 0, void 0, function* () {
+            if (!jfrogCredentials.jfrogUrl) {
+                throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
+            }
             const version = core.getInput(Utils.CLI_VERSION_ARG);
             // Version should be more than min version
             // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
             if ((version === Utils.LATEST_CLI_VERSION || (0, semver_1.gte)(version, Utils.MIN_CLI_OIDC_VERSION)) && !core.getInput(this.CLI_REMOTE_ARG)) {
                 core.debug('Using CLI Config OIDC Auth Method..');
-                return this.setOidcTokenID(jfrogCredentials);
+                jfrogCredentials.oidcTokenId = yield Utils.getIdToken(jfrogCredentials.oidcAudience);
+                return jfrogCredentials;
             }
             // Fallback to manual OIDC exchange for backward compatibility
             core.debug('Using Manual OIDC Auth Method..');
@@ -844,20 +848,9 @@ class Utils {
      */
     static manualOIDCExchange(jfrogCredentials) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!jfrogCredentials.jfrogUrl) {
-                throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
-            }
             // Get ID token from GitHub
-            core.info('Obtaining an access token through OpenID Connect...');
             const audience = core.getInput(Utils.OIDC_AUDIENCE_ARG);
-            let jsonWebToken;
-            try {
-                core.debug('Fetching JSON web token');
-                jsonWebToken = yield core.getIDToken(audience);
-            }
-            catch (error) {
-                throw new Error(`Getting openID Connect JSON web token failed: ${error.message}`);
-            }
+            let jsonWebToken = yield Utils.getIdToken(audience);
             // Exchanges the token and set as access token in the credential's object
             const applicationKey = yield this.getApplicationKey();
             try {
@@ -866,28 +859,6 @@ class Utils {
             catch (error) {
                 throw new Error(`Exchanging JSON web token with an access token failed: ${error.message}`);
             }
-        });
-    }
-    /**
-     * @param jfrogCredentials - The existing JFrog credentials
-     * @returns The updated JfrogCredentials with the OIDC tokenID
-     * @throws Error if JF_URL is not provided or if fetching the JSON web token fails
-     */
-    static setOidcTokenID(jfrogCredentials) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!jfrogCredentials.jfrogUrl) {
-                throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
-            }
-            core.info('Obtaining an access token through OpenID Connect...');
-            try {
-                core.debug('Fetching JSON web token');
-                jfrogCredentials.oidcTokenId = yield core.getIDToken(jfrogCredentials.oidcAudience);
-            }
-            catch (error) {
-                throw new Error(`Getting OpenID Connect JSON web token failed: ${error.message}`);
-            }
-            core.debug('Successfully obtained an access token through OpenID Connect');
-            return jfrogCredentials;
         });
     }
     /**
@@ -947,6 +918,23 @@ class Utils {
             }
             core.debug(`config.yml found in ${configRelativePath}`);
             return yield fs_1.promises.readFile(configRelativePath, 'utf-8');
+        });
+    }
+    /**
+     * Fetches a JSON Web Token (JWT) ID token from GitHub's OIDC provider.
+     * @param audience - The intended audience for the token.
+     * @returns A promise that resolves to the JWT ID token as a string.
+     * @throws An error if fetching the token fails.
+     */
+    static getIdToken(audience) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug('Attempting to fetch JSON Web Token (JWT) ID token...');
+            try {
+                return yield core.getIDToken(audience);
+            }
+            catch (error) {
+                throw new Error(`Failed to fetch OpenID Connect JSON Web Token: ${error.message}`);
+            }
         });
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -388,13 +388,11 @@ export class Utils {
             configCmd.push('--oidc-provider-type=Github');
             configCmd.push(`--oidc-token-id=${oidcTokenId}`);
             configCmd.push(`--oidc-audience=${oidcAudience}`);
-        }
-        // Access Token auth
-        if (accessToken) {
+            // Access Token
+        } else if (!!accessToken) {
             configCmd.push('--access-token', accessToken);
-        }
-        // Basic Auth
-        if (user && password) {
+            // Basic Auth
+        } else if (!!user && !!password) {
             configCmd.push('--user', user, '--password', password);
         }
         return configCmd;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -932,10 +932,12 @@ export class Utils {
         // Version should be more than min version
         // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
         if ((version === Utils.LATEST_CLI_VERSION || gte(version, Utils.MIN_CLI_OIDC_VERSION)) && !core.getInput(this.CLI_REMOTE_ARG)) {
+            core.debug('Using CLI Config OIDC Auth Method..');
             return this.setOidcTokenID(jfrogCredentials);
         }
 
         // Fallback to manual OIDC exchange for backward compatibility
+        core.debug('Using Manual OIDC Auth Method..');
         return this.manualOIDCExchange(jfrogCredentials);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,13 +362,13 @@ export class Utils {
      * @param jfrogCredentials existing JFrog credentials - url, access token, username + password
      */
     public static getSeparateEnvConfigArgs(jfrogCredentials: JfrogCredentials): string[] | undefined {
-    /**
-      * @name url - JFrog Platform URL
-      * @name  user&password - JFrog Platform basic authentication
-      * @name accessToken - Jfrog Platform access token
-      * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
-      * @name oidcAudience - JFrog Platform OpenID Connect audience
-     */
+        /**
+         * @name url - JFrog Platform URL
+         * @name  user&password - JFrog Platform basic authentication
+         * @name accessToken - Jfrog Platform access token
+         * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
+         * @name oidcAudience - JFrog Platform OpenID Connect audience
+         */
         let url: string | undefined = jfrogCredentials.jfrogUrl;
         let user: string | undefined = jfrogCredentials.username;
         let password: string | undefined = jfrogCredentials.password;
@@ -924,7 +924,7 @@ export class Utils {
     To support backward compatibility, we retain the old manual code.
     However, it should not be maintained and should be removed in the future.
     */
-    private static async handleOidcAuth(jfrogCredentials: JfrogCredentials): Promise<JfrogCredentials> {
+    public static async handleOidcAuth(jfrogCredentials: JfrogCredentials): Promise<JfrogCredentials> {
         const version: string = core.getInput(Utils.CLI_VERSION_ARG);
 
         // Use CLI OIDC exchange if supported
@@ -939,7 +939,7 @@ export class Utils {
     /*
     This function manually exchanges oidc token and updates the cretials object with an access token retrived
      */
-    private static async manualOIDCExchange(jfrogCredentials: JfrogCredentials) {
+    public static async manualOIDCExchange(jfrogCredentials: JfrogCredentials) {
         if (!jfrogCredentials.jfrogUrl) {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,7 +362,8 @@ export class Utils {
     public static getSeparateEnvConfigArgs(jfrogCredentials: JfrogCredentials): string[] | undefined {
         /**
          * @name url - JFrog Platform URL
-         * @name  user&password - JFrog Platform basic authentication
+         * @name user - JFrog Platform basic authentication
+         * @name password - JFrog Platform basic authentication
          * @name accessToken - Jfrog Platform access token
          * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
          * @name oidcAudience - JFrog Platform OpenID Connect audience
@@ -375,30 +376,28 @@ export class Utils {
         let oidcTokenId: string | undefined = jfrogCredentials.oidcTokenId;
         let oidcAudience: string | undefined = jfrogCredentials.oidcAudience;
 
-        if (url) {
-            let configCmd: string[] = [Utils.getServerIdForConfig(), '--url', url, '--interactive=false', '--overwrite=true'];
-            switch (true) {
-                case !!oidcProviderName:
-                    configCmd.push(`--oidc-provider-name=${oidcProviderName}`);
-                    configCmd.push('--oidc-provider-type=Github');
-                    if (oidcTokenId) {
-                        configCmd.push(`--oidc-token-id=${oidcTokenId}`);
-                    }
-                    configCmd.push(`--oidc-audience=${oidcAudience}`);
-                    break;
-                case !!accessToken:
-                    if (accessToken) {
-                        configCmd.push('--access-token', accessToken);
-                    }
-                    break;
-                case !!user && !!password:
-                    if (user && password) {
-                        configCmd.push('--user', user, '--password', password);
-                    }
-                    break;
-            }
-            return configCmd;
+        // Url is mandatory for JFrog CLI configuration
+        if (!url) {
+            return;
         }
+
+        const configCmd: string[] = [Utils.getServerIdForConfig(), '--url', url, '--interactive=false', '--overwrite=true'];
+        // OIDC auth
+        if (oidcProviderName) {
+            configCmd.push(`--oidc-provider-name=${oidcProviderName}`);
+            configCmd.push('--oidc-provider-type=Github');
+            configCmd.push(`--oidc-token-id=${oidcTokenId}`);
+            configCmd.push(`--oidc-audience=${oidcAudience}`);
+        }
+        // Access Token auth
+        if (accessToken) {
+            configCmd.push('--access-token', accessToken);
+        }
+        // Basic Auth
+        if (user && password) {
+            configCmd.push('--user', user, '--password', password);
+        }
+        return configCmd;
     }
 
     /**

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -616,6 +616,7 @@ describe('getSeparateEnvConfigArgs', () => {
             jfrogUrl: 'https://example.jfrog.io',
             oidcProviderName: 'setup-jfrog-cli',
             oidcTokenId: 'abc-123',
+            oidcAudience: 'jfrog-github',
         } as JfrogCredentials;
         const args: string[] | undefined = Utils.getSeparateEnvConfigArgs(creds);
         expect(args).toContain('--oidc-provider-name=setup-jfrog-cli');
@@ -643,7 +644,7 @@ describe('handleOidcAuth', () => {
     it('should throw if GitHub fails to return ID token', async () => {
         jest.spyOn(core, 'getIDToken').mockRejectedValue(new Error('mock failure'));
         const creds: any = { ...credentials };
-        await expect(Utils.handleOidcAuth(creds)).rejects.toThrow('Getting openID Connect JSON web token failed');
+        await expect(Utils.handleOidcAuth(creds)).rejects.toThrow('Failed to fetch OpenID Connect JSON Web Token');
     });
 
     it('should call setOidcTokenID when CLI version is >= 2.75.0', async () => {
@@ -652,10 +653,7 @@ describe('handleOidcAuth', () => {
             return '';
         });
         jest.spyOn(semver, 'gte').mockReturnValue(true);
-        jest.spyOn(Utils as any, 'setOidcTokenID').mockResolvedValue({
-            ...credentials,
-            oidcTokenId: 'mock-token-id',
-        });
+        jest.spyOn(Utils as any, 'getIdToken').mockResolvedValue('mock-token-id');
 
         const result: JfrogCredentials = await (Utils as any).handleOidcAuth(credentials);
         expect(result.oidcTokenId).toBe('mock-token-id');

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -528,46 +528,6 @@ describe('getApplicationKey', () => {
     });
 });
 
-describe('setUsageEnvVars', () => {
-    beforeEach(() => {
-        // Clear environment variables before each test
-        delete process.env.GITHUB_REPOSITORY;
-        delete process.env.GITHUB_WORKFLOW;
-        delete process.env.GITHUB_RUN_ID;
-        delete process.env.JF_GIT_TOKEN;
-
-        jest.clearAllMocks();
-    });
-
-    it('should export the correct environment variables when all inputs are set', () => {
-        // Mock environment variables
-        process.env.GITHUB_REPOSITORY = 'owner/repo';
-        process.env.GITHUB_WORKFLOW = 'test-workflow';
-        process.env.GITHUB_RUN_ID = '12345';
-        process.env.JF_GIT_TOKEN = 'dummy-token';
-
-        // Call the function
-        Utils.setUsageEnvVars();
-
-        // Verify exported variables
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_JOB_ID', 'test-workflow');
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_RUN_ID', '12345');
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_GIT_REPO', 'owner/repo');
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED', true);
-    });
-
-    it('should export empty strings for missing environment variables', () => {
-        // Call the function with no environment variables set
-        Utils.setUsageEnvVars();
-
-        // Verify exported variables
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_JOB_ID', '');
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_RUN_ID', '');
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_GIT_REPO', '');
-        expect(core.exportVariable).toHaveBeenCalledWith('JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED', false);
-    });
-});
-
 describe('Test correct encoding of badge URL', () => {
     describe('getUsageBadge', () => {
         beforeEach(() => {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

## 🔐 OIDC Authentication Flow Support

This project now supports **two OpenID Connect (OIDC) authentication flows**, depending on the JFrog CLI version and how it is used:

---

### ✅ Native OIDC Integration (Recommended)

- **Used when:**
  - JFrog CLI version is `>= 2.75.0` 
  - You are **not** downloading the CLI from a remote Artifactory repository

- **Behavior:**
  - Uses the JFrog CLI's built-in `--oidc-token-id` support
  - No need to manually exchange tokens

---

### 🔁 Manual OIDC Fallback (Legacy or Remote CLI Download)

- **Used when:**
  - JFrog CLI version is **older than** `2.75.0`, **or**
  - A CLI is downloaded using a remote Artifactory repository (via `--download-repository`)

- **Behavior:**
  - Uses GitHub’s OIDC token to **manually fetch** a JFrog access token via the REST API
  - Ensures backward compatibility and support for remote execution contexts

---

## 🧪 Integration Test Workflows

To ensure correct behavior across environments:

- `cli-oidc-test.yml`: Verifies **native OIDC flow**
- `manual-oidc-test.yml`: Verifies **manual fallback path**

---

## ✅ Improvements & Cleanup

- Deprecated and removed: `setUsageEnvVars()` legacy logic
- Added test coverage for:
  - CLI version fallbacks
  - OIDC failures
  - Remote download cases
- Introduced constants for clarity and maintainability:
  - `MIN_CLI_OIDC_VERSION`
  - `DEFAULT_OIDC_AUDIENCE`
  - `CLI_REMOTE_ARG`
- Enhanced logging and credential-handling transparency

---

## 🧼 Future Outlook

Once all JFrog CLI usage paths—including remote downloads—support `--oidc-token-id`, the **manual fallback logic will be removed** for cleaner and more secure operation.

