### PR TITLE
Promote version to `v4.5.7`

### DIFF
--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
-
 
 # Ensures that only the latest commit is running for each PR at a time.
 concurrency:

--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -26,9 +26,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          ref:
-            ${{ github.event.pull_request.head.ref || github.sha }}
 
       - name: Setup JFrog CLI
         id: setup-jfrog-cli

--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup JFrog CLI
         id: setup-jfrog-cli

--- a/.github/workflows/manual-oidc-test.yml
+++ b/.github/workflows/manual-oidc-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Generating a unique name for the Integration Configuration that will be created in the following step
       - name: Generate unique OIDC config name

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.5.6",
+    "version": "4.5.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.5.6",
+    "version": "4.5.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@jfrog/setup-jfrog-cli",
-            "version": "4.5.6",
+            "version": "4.5.7",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.5.6",
+    "version": "4.5.7",
     "private": true,
     "description": "Setup JFrog CLI in GitHub Actions",
     "main": "lib/main.js",


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

## 🔄 Bump Version to 4.5.7 and Minor Workflow Cleanup

### ✅ What's Changed

- ⬆️ **Version bump**:  
  Updated `package.json` and both lock files to version **4.5.7**.

- 🧼 **GitHub Action cleanup**:  
  - Added `ref` input from the `actions/checkout` step in `.github/workflows/cli-oidc-test.yml`.  
  - Cleaned up minor whitespace and indentation inconsistencies.

### 🔍 Why?

- The `ref` input should fix checkout failure while running e2e tests from PRs
