### PR TITLE
Downgrade default CLI version

### DIFF
--- a/.github/workflows/cli-oidc-test.yml
+++ b/.github/workflows/cli-oidc-test.yml
@@ -36,6 +36,8 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           oidc-provider-name: setup-jfrog-cli-test
+          # This can be removed after the default CLI version will be updated
+          version: 2.75.0
 
       - name: Test JFrog CLI
         run: |

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "JFrog"
 inputs:
     version:
         description: "JFrog CLI Version"
-        default: "2.75.0"
+        default: "2.74.1"
         required: false
     download-repository:
         description: "Remote repository in Artifactory pointing to 'https://releases.jfrog.io/artifactory/jfrog-cli'. Use this parameter in case you don't have an Internet access."

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.5.7",
+    "version": "4.5.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.5.7",
+    "version": "4.5.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@jfrog/setup-jfrog-cli",
-            "version": "4.5.7",
+            "version": "4.5.8",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jfrog/setup-jfrog-cli",
-    "version": "4.5.7",
+    "version": "4.5.8",
     "private": true,
     "description": "Setup JFrog CLI in GitHub Actions",
     "main": "lib/main.js",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

### Why

This PR downgrades the default JFrog CLI version used in the action to avoid breaking existing workflows that rely on the `setup-jfrog-cli` step outputs — specifically those related to OIDC authentication.

In recent CLI versions, the OIDC token exchange logic was moved inside the CLI itself. As a result, the access token is no longer exposed via step outputs, which broke pipelines that depended on this behavior.

### What’s Changing

- Downgrade the default CLI version to restore the previous behavior where the access token is available as a step output.
