### PR TITLE
Fix OIDC audience default value

### DIFF
--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -91,14 +91,14 @@ jobs:
             audience_value: 'test-audience'
           - cli-version: '2.74.1'
             audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
+            audience_value: ''
           - cli-version: '2.75.0'
             audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
+            audience_value: ''
           - cli-version: latest
             audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
-    runs-on: ${{ matrix.os }}-latest
+            audience_value: ''
+    runs-on: ubuntu-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
     steps:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -102,7 +102,7 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           version: ${{ matrix.cli-version }}
-          oidc-provider-name: ${{ needs.generate-oidc-integration.outputs.oidc_provider_name }}
+          oidc-provider-name: ${{ needs.generate-platform-oidc-integration.outputs.oidc_provider_name }}
           oidc-audience: ${{ matrix.audience_value }}
 
       - name: Test JFrog CLI connectivity
@@ -119,9 +119,10 @@ jobs:
   cleanup-oidc-integration:
     needs: oidc-test
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - name: Delete OIDC integration
         shell: bash
         run: |
-          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/${{ needs.generate-oidc-integration.outputs.oidc_provider_name }}" \
+          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/${{ needs.generate-platform-oidc-integration.outputs.oidc_provider_name }}" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         cli-version: ['2.74.1', '2.75.0', 'latest']
-        audience_value: ['', 'test-audience']
+        audience_value: ['', 'test-audience','https://github.com/eyaldelarea']
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
@@ -107,7 +107,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        audience_value: ['', 'test-audience']
+        audience_value: ['', 'test-audience','https://github.com/eyaldelarea']
     runs-on: ubuntu-latest
     steps:
       - name: Delete OIDC integration

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -9,7 +9,8 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-      - master
+      #- master
+      - "**"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -9,7 +9,7 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-      - master
+      - "**"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
@@ -29,6 +29,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
+        audience_value: [ '' ,'','test-assigned' ]
     runs-on: ${{ matrix.os }}-latest
     name: OIDC Test - ${{ matrix.cli-version }} on ${{ matrix.os }}
     env:
@@ -58,6 +59,7 @@ jobs:
               "name": "${{ steps.gen-oidc.outputs.oidc_provider_name }}",
               "issuer_url": "https://token.actions.githubusercontent.com",
               "provider_type": "GitHub",
+              "audience": ${{ matrix.audience_value }},",
               "enable_permissive_configuration": "true",
               "description": "Test configuration for CLI version ${{ matrix.cli-version }}"
             }'
@@ -76,7 +78,7 @@ jobs:
               },
               "token_spec": {
                 "scope": "applied-permissions/groups:readers",
-                "expires_in": 30
+                "expires_in": 10
               }
             }'
 
@@ -89,6 +91,7 @@ jobs:
         with:
           version: ${{ matrix.cli-version }}
           oidc-provider-name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
+          oidc-audience: ${{ matrix.audience_value }}
 
       # validate successful OIDC configuration
       - name: Test JFrog CLI connectivity

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -18,9 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  AUDIENCE_VALUES: "['', 'test-audience', 'github-jfrog']"
-
 permissions:
   id-token: write
   contents: read
@@ -29,7 +26,7 @@ jobs:
   generate-oidc-integration:
     strategy:
       matrix:
-        audience_value: ${{ fromJson(env.AUDIENCE_VALUES) }}
+        audience_value: ${{ fromJson('["", "test-audience", "github-jfrog"]') }}
     runs-on: ubuntu-latest
     outputs:
       oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
@@ -83,8 +80,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        cli-version: [ '2.74.1', '2.75.0','latest' ]
-        audience_value: ${{ fromJson(env.AUDIENCE_VALUES) }}
+        cli-version: [ '2.74.1', '2.75.0', 'latest' ]
+        audience_value: ${{ fromJson('["", "test-audience", "github-jfrog"]') }}
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -26,6 +26,8 @@ jobs:
             audience_value: ''
           - audience_id: test
             audience_value: 'test-audience'
+            # When not provided, GitHub resolves the audience value to the URL of the GitHub repository owner.
+            # This test makes sure this issue won't happen again https://github.com/jfrog/setup-jfrog-cli/issues/270.
           - audience_id: github-default
             audience_value: 'https://github.com/EyalDelarea'
     runs-on: ubuntu-latest
@@ -69,18 +71,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu
-            cli-version: '2.74.1'
+          - cli-version: '2.74.1'
             audience_id: default
             audience_value: ''
-          - os: ubuntu
-            cli-version: '2.75.0'
+          - cli-version: '2.75.0'
+            audience_id: default
+            audience_value: ''
+          - cli-version: latest
+            audience_id: default
+            audience_value: ''
+          - cli-version: '2.74.1'
             audience_id: test
             audience_value: 'test-audience'
-          - os: ubuntu
-            cli-version: latest
+          - cli-version: '2.75.0'
+            audience_id: test
+            audience_value: 'test-audience'
+          - cli-version: latest
+            audience_id: test
+            audience_value: 'test-audience'
+          - cli-version: '2.74.1'
             audience_id: github-default
-            audience_value: ''
+            audience_value: 'https://github.com/eyaldelarea'
+          - cli-version: '2.75.0'
+            audience_id: github-default
+            audience_value: 'https://github.com/eyaldelarea'
+          - cli-version: latest
+            audience_id: github-default
+            audience_value: 'https://github.com/eyaldelarea'
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
@@ -111,19 +128,19 @@ jobs:
         shell: bash
         run: test -n "${{ steps.setup-jfrog-cli.outputs.oidc-token }}"
 
-#  cleanup-oidc-integration:
-#    needs: oidc-test
-#    if: always()
-#    strategy:
-#      matrix:
-#        include:
-#          - audience_id: default
-#          - audience_id: test
-#          - audience_id: github-default
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Delete OIDC integration
-#        shell: bash
-#        run: |
-#          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}" \
-#            -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"
+  cleanup-oidc-integration:
+    needs: oidc-test
+    if: always()
+    strategy:
+      matrix:
+        include:
+          - audience_id: default
+          - audience_id: test
+          - audience_id: github-default
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete OIDC integration
+        shell: bash
+        run: |
+          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}" \
+            -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -111,7 +111,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        audience_value: ['', 'test-audience', 'github-jfrog']
+        audience_value: ['', 'test-audience']
     runs-on: ubuntu-latest
     steps:
       - name: Delete OIDC integration

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -27,7 +27,7 @@ jobs:
   generate-platform-oidc-integration:
     strategy:
       matrix:
-        audience_value: ['', 'test-audience', 'github-jfrog']
+        audience_value: ['', 'test-audience']
     runs-on: ubuntu-latest
     steps:
       - name: Generate unique OIDC provider name
@@ -75,7 +75,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         cli-version: ['2.74.1', '2.75.0', 'latest']
-        audience_value: ['', 'test-audience', 'github-jfrog']
+        audience_value: ['', 'test-audience']
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -80,7 +80,7 @@ jobs:
           - os: ubuntu
             cli-version: latest
             audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
+            audience_value: ''
           - os: macos
             cli-version: latest
             audience_id: github-default

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -26,6 +26,7 @@ jobs:
   generate-oidc-integration:
     strategy:
       matrix:
+        # This has to match the second audience value in the workflow
         audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ubuntu-latest
     outputs:
@@ -81,6 +82,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
+        # This has to match the second audience value in the workflow
         audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ${{ matrix.os }}-latest
     env:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -1,14 +1,19 @@
 name: OIDC Integration Test
 # This workflow tests the setup-jfrog-cli GitHub Action's OpenID Connect integration across OSes and CLI versions.
 # It ensures backward compatibility with older CLI versions and validates step outputs and connectivity.
-
+# CLI versions used:
+# - 2.74.1: Does not support `jf eot` command, validates manual fallback logic.
+# - 2.75.0: Introduced native OIDC token exchange.
+# - Latest: Ensures ongoing compatibility with the most recent CLI build.
 on:
   push:
     branches:
-      - master
+#      - master
+      - "**"
+  # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
-
+# Ensures that only the latest commit is running for each PR at a time.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,6 +25,14 @@ permissions:
 jobs:
   generate-platform-oidc-integration:
     strategy:
+      # Using "include" here instead of a typical matrix of arrays gives us granular control over combinations.
+      # This is necessary because we need to generate different audience values, some of which contain characters
+      # not suitable for dynamic naming or matrix keys.
+      # Each audience represents a different real-world use case:
+      # - "default": no audience provided, tests implicit GitHub behavior.
+      # - "test": explicitly defined audience for testing purposes.
+      # - "github-explicit-default": GitHub's default audience (explicitly passed) to test edge behavior,
+      # when a user is defining the default audience in the platform but not in the action (leaving empty).
       matrix:
         include:
           - audience_id: default
@@ -28,8 +41,8 @@ jobs:
             audience_value: 'test-audience'
             # When not provided, GitHub resolves the audience value to the URL of the GitHub repository owner.
             # This test makes sure this issue won't happen again https://github.com/jfrog/setup-jfrog-cli/issues/270.
-          - audience_id: github-default
-            audience_value: 'https://github.com/jfrog'
+          - audience_id: github-explicit-default
+            audience_value: 'https://github.com/EyalDelarea'
     runs-on: ubuntu-latest
     steps:
       - name: Create OpenID Connect integration
@@ -69,6 +82,8 @@ jobs:
     needs: generate-platform-oidc-integration
     strategy:
       fail-fast: false
+      # Using include allows exact combinations of CLI version and audience ID to ensure coverage of edge cases.
+      # This avoids invalid audience strings in identifiers and ensures fallback logic is tested selectively.
       matrix:
         include:
           - cli-version: '2.74.1'
@@ -90,13 +105,15 @@ jobs:
             audience_id: test
             audience_value: 'test-audience'
           - cli-version: '2.74.1'
-            audience_id: github-default
+            audience_id: github-explicit-default
+            # GitHub default audience value is resolved implicitly when omitted.
+            # These tests verify that the CLI handles an empty value correctly while GitHub sets the expected audience on its backend.
             audience_value: ''
           - cli-version: '2.75.0'
-            audience_id: github-default
+            audience_id: github-explicit-default
             audience_value: ''
           - cli-version: latest
-            audience_id: github-default
+            audience_id: github-explicit-default
             audience_value: ''
     runs-on: ubuntu-latest
     env:
@@ -136,7 +153,7 @@ jobs:
         include:
           - audience_id: default
           - audience_id: test
-          - audience_id: github-default
+          - audience_id: github-explicit-default
     runs-on: ubuntu-latest
     steps:
       - name: Delete OIDC integration

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -23,31 +23,19 @@ permissions:
   contents: read
 
 jobs:
-  oidc-test:
+  generate-oidc-integration:
     strategy:
-      fail-fast: false
       matrix:
-        os: [ ubuntu, macos, windows ]
-        cli-version: [ '2.74.1', '2.75.0','latest' ]
         audience_value: [ '' ,'test-audience','github-jfrog' ]
-    runs-on: ${{ matrix.os }}-latest
-    name: OIDC Test - ${{ matrix.cli-version }} on ${{ matrix.os }}
-    env:
-      JFROG_CLI_LOG_LEVEL: DEBUG
-
+    runs-on: ubuntu-latest
+    outputs:
+      oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      # Setup OIDC platform integration
       - name: Generate unique OIDC provider name
         id: gen-oidc
         shell: bash
         run: |
-          cli_version="${{ matrix.cli-version }}" && cli_version="${cli_version//./-}"
-          echo "oidc_provider_name=oidc-integration-${cli_version}-${{ matrix.os }}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          echo "oidc_provider_name=oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
 
       - name: Create OpenID Connect integration
         shell: bash
@@ -61,7 +49,7 @@ jobs:
               "provider_type": "GitHub",
               "audience": "${{ matrix.audience_value }}",
               "enable_permissive_configuration": "true",
-              "description": "Test configuration for CLI version ${{ matrix.cli-version }}"
+              "description": "Test configuration for audience ${{ matrix.audience_value }}"
             }'
 
       - name: Create OIDC Identity Mapping
@@ -82,7 +70,27 @@ jobs:
               }
             }'
 
-      # Setup
+      - name: Save OIDC provider name
+        shell: bash
+        run: echo "oidc_provider_name=${{ steps.gen-oidc.outputs.oidc_provider_name }}" >> "$GITHUB_ENV"
+
+  oidc-test:
+    needs: generate-oidc-integration
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu, macos, windows ]
+        cli-version: [ '2.74.1', '2.75.0','latest' ]
+        audience_value: [ '' ,'test-audience','github-jfrog' ]
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Setup JFrog CLI
         id: setup-jfrog-cli
         uses: ./
@@ -90,14 +98,12 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           version: ${{ matrix.cli-version }}
-          oidc-provider-name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
+          oidc-provider-name: ${{ needs.generate-oidc-integration.outputs.oidc_provider_name }}
           oidc-audience: ${{ matrix.audience_value }}
 
-      # validate successful OIDC configuration
       - name: Test JFrog CLI connectivity
         run: jf rt ping
 
-      # Validate step outputs
       - name: Validate user output
         shell: bash
         run: test -n "${{ steps.setup-jfrog-cli.outputs.oidc-user }}"
@@ -106,10 +112,12 @@ jobs:
         shell: bash
         run: test -n "${{ steps.setup-jfrog-cli.outputs.oidc-token }}"
 
-      # Cleanup
+  cleanup-oidc-integration:
+    needs: oidc-test
+    runs-on: ubuntu-latest
+    steps:
       - name: Delete OIDC integration
         shell: bash
-        if: always()
         run: |
-          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/${{ steps.gen-oidc.outputs.oidc_provider_name }}" \
+          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/${{ needs.generate-oidc-integration.outputs.oidc_provider_name }}" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -26,7 +26,7 @@ jobs:
   generate-oidc-integration:
     strategy:
       matrix:
-        audience_value: ${{ fromJson('["", "test-audience", "github-jfrog"]') }}
+        audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ubuntu-latest
     outputs:
       oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
@@ -80,8 +80,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        cli-version: [ '2.74.1', '2.75.0', 'latest' ]
-        audience_value: ${{ fromJson('["", "test-audience", "github-jfrog"]') }}
+        cli-version: [ '2.74.1', '2.75.0','latest' ]
+        audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
+        audience_value: [ '' ,'','github-jfrog' ]
     runs-on: ${{ matrix.os }}-latest
     name: OIDC Test - ${{ matrix.cli-version }} on ${{ matrix.os }}
     env:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -59,7 +59,7 @@ jobs:
               "name": "${{ steps.gen-oidc.outputs.oidc_provider_name }}",
               "issuer_url": "https://token.actions.githubusercontent.com",
               "provider_type": "GitHub",
-              "audience": "${{ matrix.audience_value }},",
+              "audience": "${{ matrix.audience_value }}",
               "enable_permissive_configuration": "true",
               "description": "Test configuration for CLI version ${{ matrix.cli-version }}"
             }'

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - master
-      - "**"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  AUDIENCE_VALUES: "['', 'test-audience', 'github-jfrog']"
+
 permissions:
   id-token: write
   contents: read
@@ -26,7 +29,7 @@ jobs:
   generate-oidc-integration:
     strategy:
       matrix:
-        audience_value: [ '' ,'test-audience','github-jfrog' ]
+        audience_value: ${{ env.AUDIENCE_VALUES }}
     runs-on: ubuntu-latest
     outputs:
       oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
@@ -81,7 +84,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
-        audience_value: [ '' ,'test-audience','github-jfrog' ]
+        audience_value: ${{ env.AUDIENCE_VALUES }}
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -1,21 +1,12 @@
 name: OIDC Integration Test
-# This workflow tests the setup-jfrog-cli GitHub Action's OpenID Connect integration across OSes and CLI versions.
-# It ensures backward compatibility with older CLI versions and validates step outputs and connectivity.
-# CLI versions used:
-# - 2.74.1: Does not support `jf eot` command, validates manual fallback logic.
-# - 2.75.0: Introduced native OIDC token exchange.
-# - Latest: Ensures ongoing compatibility with the most recent CLI build.
 
 on:
   push:
     branches:
-      # - master
-      # TODO remove this before merge
       - "**"
-  # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
-# Ensures that only the latest commit is running for each PR at a time.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,12 +15,16 @@ permissions:
   id-token: write
   contents: read
 
+audience_values: &audience_values
+  - ''
+  - 'test-audience'
+  - 'github-jfrog'
+
 jobs:
   generate-platform-oidc-integration:
     strategy:
       matrix:
-        # This has to match the second audience value in the workflow, under oidc-test matrix.
-        audience_value: [ '' ,'test-audience','github-jfrog' ]
+        audience_value: *audience_values
     runs-on: ubuntu-latest
     outputs:
       oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
@@ -83,9 +78,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        cli-version: [ '2.74.1', '2.75.0','latest' ]
-        # This has to match the second audience value in the workflow under generate-oidc-integration matrix.
-        audience_value: [ '' ,'test-audience','github-jfrog' ]
+        cli-version: [ '2.74.1', '2.75.0', 'latest' ]
+        audience_value: *audience_values
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
@@ -118,11 +112,14 @@ jobs:
 
   cleanup-oidc-integration:
     needs: oidc-test
+    strategy:
+      matrix:
+        audience_value: *audience_values
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Delete OIDC integration
         shell: bash
         run: |
-          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/${{ needs.generate-platform-oidc-integration.outputs.oidc_provider_name }}" \
+          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -9,7 +9,7 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-      - "**"
+      - "master"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
@@ -26,7 +26,7 @@ jobs:
   generate-oidc-integration:
     strategy:
       matrix:
-        # This has to match the second audience value in the workflow
+        # This has to match the second audience value in the workflow, under oidc-test matrix.
         audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ubuntu-latest
     outputs:
@@ -82,7 +82,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
-        # This has to match the second audience value in the workflow
+        # This has to match the second audience value in the workflow under generate-oidc-integration matrix.
         audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ${{ matrix.os }}-latest
     env:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -8,7 +8,7 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-#      - master
+      - master
       - "**"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
@@ -25,24 +25,23 @@ permissions:
 jobs:
   generate-platform-oidc-integration:
     strategy:
-      # Using "include" here instead of a typical matrix of arrays gives us granular control over combinations.
-      # This is necessary because we need to generate different audience values, some of which contain characters
-      # not suitable for dynamic naming or matrix keys.
-      # Each audience represents a different real-world use case:
-      # - "default": no audience provided, tests implicit GitHub behavior.
-      # - "test": explicitly defined audience for testing purposes.
-      # - "github-explicit-default": GitHub's default audience (explicitly passed) to test edge behavior,
-      # when a user is defining the default audience in the platform but not in the action.
+      # Using "include" instead of a matrix of arrays gives us fine-grained control over test combinations.
+      # This is needed because some audience values (e.g., URLs) contain characters not valid in matrix keys or job names.
+      #
+      # Each scenario represents a real-world case:
+      # - "default": No audience is set in the action or the platform integration.
+      # - "test": A custom audience is explicitly set in both the action and the platform integration.
+      # - "github-implicit-default": The platform integration is explicitly configured with GitHub's default audience,
+      #    but the action does not pass any audience.
+      #    This tests CLI behavior in case of mismatches — see https://github.com/jfrog/setup-jfrog-cli/issues/270
       matrix:
         include:
           - audience_id: default
             audience_value: ''
           - audience_id: test
-            audience_value: 'test-audience'
-            # When not provided, GitHub resolves the audience value to the URL of the GitHub repository owner.
-            # This test makes sure this issue won't happen again https://github.com/jfrog/setup-jfrog-cli/issues/270.
-          - audience_id: github-explicit-default
-            audience_value: 'https://github.com/EyalDelarea'
+            audience_value: 'audience-value'
+          - audience_id: github-implicit-default
+            audience_value: 'https://github.com/jfrog'
     runs-on: ubuntu-latest
     steps:
       - name: Create OpenID Connect integration
@@ -97,23 +96,23 @@ jobs:
             audience_value: ''
           - cli-version: '2.74.1'
             audience_id: test
-            audience_value: 'test-audience'
+            audience_value: 'audience-value'
           - cli-version: '2.75.0'
             audience_id: test
-            audience_value: 'test-audience'
+            audience_value: 'audience-value'
           - cli-version: latest
             audience_id: test
-            audience_value: 'test-audience'
+            audience_value: 'audience-value'
             # GitHub default audience value is resolved implicitly when omitted.
             # These tests verify that the CLI handles an empty value correctly while GitHub sets the expected audience on its backend.
           - cli-version: '2.74.1'
-            audience_id: github-explicit-default
+            audience_id: github-implicit-default
             audience_value: ''
           - cli-version: '2.75.0'
-            audience_id: github-explicit-default
+            audience_id: github-implicit-default
             audience_value: ''
           - cli-version: latest
-            audience_id: github-explicit-default
+            audience_id: github-implicit-default
             audience_value: ''
     runs-on: ubuntu-latest
     env:
@@ -153,7 +152,7 @@ jobs:
         include:
           - audience_id: default
           - audience_id: test
-          - audience_id: github-explicit-default
+          - audience_id: github-implicit-default
     runs-on: ubuntu-latest
     steps:
       - name: Delete OIDC integration

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -81,14 +81,6 @@ jobs:
             cli-version: latest
             audience_id: github-default
             audience_value: ''
-          - os: macos
-            cli-version: latest
-            audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
-          - os: windows
-            cli-version: latest
-            audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
@@ -119,19 +111,19 @@ jobs:
         shell: bash
         run: test -n "${{ steps.setup-jfrog-cli.outputs.oidc-token }}"
 
-  cleanup-oidc-integration:
-    needs: oidc-test
-    if: always()
-    strategy:
-      matrix:
-        include:
-          - audience_id: default
-          - audience_id: test
-          - audience_id: github-default
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete OIDC integration
-        shell: bash
-        run: |
-          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}" \
-            -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"
+#  cleanup-oidc-integration:
+#    needs: oidc-test
+#    if: always()
+#    strategy:
+#      matrix:
+#        include:
+#          - audience_id: default
+#          - audience_id: test
+#          - audience_id: github-default
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Delete OIDC integration
+#        shell: bash
+#        run: |
+#          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}" \
+#            -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         # Test with a default and provided audience value
-        audience_value: ['', 'test-audience']
+        audience_value: ['', 'test-audience','https://github.com/eyaldelarea']
     runs-on: ubuntu-latest
     steps:
       - name: Create OpenID Connect integration
@@ -43,7 +43,7 @@ jobs:
               "provider_type": "GitHub",
               "audience": "${{ matrix.audience_value }}",
               "enable_permissive_configuration": true,
-              "description": "Temp integration for testing OIDC with audience: ${{ matrix.audience_value }}"
+              "description": "Temp integration for testing OIDC with audience value: ${{ matrix.audience_value }}"
             }'
 
       - name: Create OIDC Identity Mapping

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -9,7 +9,9 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-      - master
+      # - master
+      # TODO remove this before merge
+      - "**"
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "**"
   pull_request_target:
-    types: [ labeled ]
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
@@ -15,25 +15,17 @@ permissions:
   id-token: write
   contents: read
 
-audience_values: &audience_values
-  - ''
-  - 'test-audience'
-  - 'github-jfrog'
-
 jobs:
   generate-platform-oidc-integration:
     strategy:
       matrix:
-        audience_value: *audience_values
+        audience_value: ['', 'test-audience', 'github-jfrog']
     runs-on: ubuntu-latest
-    outputs:
-      oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
     steps:
       - name: Generate unique OIDC provider name
         id: gen-oidc
         shell: bash
-        run: |
-          echo "oidc_provider_name=oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+        run: echo "oidc_provider_name=oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
 
       - name: Create OpenID Connect integration
         shell: bash
@@ -42,23 +34,23 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" \
             -d '{
-              "name": "${{ steps.gen-oidc.outputs.oidc_provider_name }}",
+              "name": "oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}",
               "issuer_url": "https://token.actions.githubusercontent.com",
               "provider_type": "GitHub",
               "audience": "${{ matrix.audience_value }}",
-              "enable_permissive_configuration": "true",
+              "enable_permissive_configuration": true,
               "description": "Temp integration for testing OIDC with audience: ${{ matrix.audience_value }}"
             }'
 
       - name: Create OIDC Identity Mapping
         shell: bash
         run: |
-          curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/${{ steps.gen-oidc.outputs.oidc_provider_name }}/identity_mappings" \
-            -H 'Content-Type: application/json' \
+          curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}/identity_mappings" \
+            -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" \
             -d '{
               "name": "oidc-test-mapping",
-              "priority": "1",
+              "priority": 1,
               "claims": {
                 "repository": "${{ github.repository_owner }}/setup-jfrog-cli"
               },
@@ -68,18 +60,14 @@ jobs:
               }
             }'
 
-      - name: Save OIDC provider name
-        shell: bash
-        run: echo "oidc_provider_name=${{ steps.gen-oidc.outputs.oidc_provider_name }}" >> "$GITHUB_ENV"
-
   oidc-test:
     needs: generate-platform-oidc-integration
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, macos, windows ]
-        cli-version: [ '2.74.1', '2.75.0', 'latest' ]
-        audience_value: *audience_values
+        os: [ubuntu, macos, windows]
+        cli-version: ['2.74.1', '2.75.0', 'latest']
+        audience_value: ['', 'test-audience', 'github-jfrog']
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
@@ -96,7 +84,7 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           version: ${{ matrix.cli-version }}
-          oidc-provider-name: ${{ needs.generate-platform-oidc-integration.outputs.oidc_provider_name }}
+          oidc-provider-name: oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}
           oidc-audience: ${{ matrix.audience_value }}
 
       - name: Test JFrog CLI connectivity
@@ -112,11 +100,11 @@ jobs:
 
   cleanup-oidc-integration:
     needs: oidc-test
+    if: always()
     strategy:
       matrix:
-        audience_value: *audience_values
+        audience_value: ['', 'test-audience', 'github-jfrog']
     runs-on: ubuntu-latest
-    if: always()
     steps:
       - name: Delete OIDC integration
         shell: bash

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -5,7 +5,7 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-      - "**"
+      - master
   pull_request_target:
     types: [ labeled ]
 
@@ -29,7 +29,7 @@ jobs:
             # When not provided, GitHub resolves the audience value to the URL of the GitHub repository owner.
             # This test makes sure this issue won't happen again https://github.com/jfrog/setup-jfrog-cli/issues/270.
           - audience_id: github-default
-            audience_value: 'https://github.com/EyalDelarea'
+            audience_value: 'https://github.com/jfrog'
     runs-on: ubuntu-latest
     steps:
       - name: Create OpenID Connect integration

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -29,7 +29,6 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
-        audience_value: [ '' ,'','test-assigned' ]
     runs-on: ${{ matrix.os }}-latest
     name: OIDC Test - ${{ matrix.cli-version }} on ${{ matrix.os }}
     env:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           cli_version="${{ matrix.cli-version }}" && cli_version="${cli_version//./-}"
-          echo "oidc_provider_name=oidc-integration-${cli_version}-${{ matrix.os }}-$(date +%s)" >> "$GITHUB_OUTPUT"
+          echo "oidc_provider_name=oidc-integration-${cli_version}-${{ matrix.os }}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
 
       - name: Create OpenID Connect integration
         shell: bash

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -29,7 +29,7 @@ jobs:
   generate-oidc-integration:
     strategy:
       matrix:
-        audience_value: ${{ env.AUDIENCE_VALUES }}
+        audience_value: ${{ fromJson(env.AUDIENCE_VALUES) }}
     runs-on: ubuntu-latest
     outputs:
       oidc_provider_name: ${{ steps.gen-oidc.outputs.oidc_provider_name }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
-        audience_value: ${{ env.AUDIENCE_VALUES }}
+        audience_value: ${{ fromJson(env.AUDIENCE_VALUES) }}
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -1,20 +1,14 @@
 name: OIDC Integration Test
 # This workflow tests the setup-jfrog-cli GitHub Action's OpenID Connect integration across OSes and CLI versions.
 # It ensures backward compatibility with older CLI versions and validates step outputs and connectivity.
-# CLI versions used:
-# - 2.74.1: Does not support `jf eot` command, validates manual fallback logic.
-# - 2.75.0: Introduced native OIDC token exchange.
-# - Latest: Ensures ongoing compatibility with the most recent CLI build.
 
 on:
   push:
     branches:
-      #- master
       - "**"
-  # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
-# Ensures that only the latest commit is running for each PR at a time.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true
@@ -27,8 +21,13 @@ jobs:
   generate-platform-oidc-integration:
     strategy:
       matrix:
-        # Test with a default and provided audience value
-        audience_value: ['', 'test-audience','https://github.com/eyaldelarea']
+        include:
+          - audience_id: default
+            audience_value: ''
+          - audience_id: test
+            audience_value: 'test-audience'
+          - audience_id: github-default
+            audience_value: 'https://github.com/eyaldelarea'
     runs-on: ubuntu-latest
     steps:
       - name: Create OpenID Connect integration
@@ -38,7 +37,7 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" \
             -d '{
-              "name": "oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}",
+              "name": "oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}",
               "issuer_url": "https://token.actions.githubusercontent.com",
               "provider_type": "GitHub",
               "audience": "${{ matrix.audience_value }}",
@@ -49,7 +48,7 @@ jobs:
       - name: Create OIDC Identity Mapping
         shell: bash
         run: |
-          curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}/identity_mappings" \
+          curl -X POST "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}/identity_mappings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}" \
             -d '{
@@ -69,9 +68,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
-        cli-version: ['2.74.1', '2.75.0', 'latest']
-        audience_value: ['', 'test-audience','https://github.com/eyaldelarea']
+        include:
+          - os: ubuntu
+            cli-version: '2.74.1'
+            audience_id: default
+            audience_value: ''
+          - os: ubuntu
+            cli-version: '2.75.0'
+            audience_id: test
+            audience_value: 'test-audience'
+          - os: ubuntu
+            cli-version: latest
+            audience_id: github-default
+            audience_value: 'https://github.com/eyaldelarea'
+          - os: macos
+            cli-version: latest
+            audience_id: github-default
+            audience_value: 'https://github.com/eyaldelarea'
+          - os: windows
+            cli-version: latest
+            audience_id: github-default
+            audience_value: 'https://github.com/eyaldelarea'
     runs-on: ${{ matrix.os }}-latest
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
@@ -88,7 +105,7 @@ jobs:
           JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         with:
           version: ${{ matrix.cli-version }}
-          oidc-provider-name: oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}
+          oidc-provider-name: oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}
           oidc-audience: ${{ matrix.audience_value }}
 
       - name: Test JFrog CLI connectivity
@@ -107,11 +124,14 @@ jobs:
     if: always()
     strategy:
       matrix:
-        audience_value: ['', 'test-audience','https://github.com/eyaldelarea']
+        include:
+          - audience_id: default
+          - audience_id: test
+          - audience_id: github-default
     runs-on: ubuntu-latest
     steps:
       - name: Delete OIDC integration
         shell: bash
         run: |
-          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}" \
+          curl -X DELETE "${{ secrets.JFROG_PLATFORM_URL }}/access/api/v1/oidc/oidc-integration-${{ matrix.audience_id }}-${{ github.run_id }}" \
             -H "Authorization: Bearer ${{ secrets.JFROG_PLATFORM_RT_TOKEN }}"

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -32,7 +32,7 @@ jobs:
       # - "default": no audience provided, tests implicit GitHub behavior.
       # - "test": explicitly defined audience for testing purposes.
       # - "github-explicit-default": GitHub's default audience (explicitly passed) to test edge behavior,
-      # when a user is defining the default audience in the platform but not in the action (leaving empty).
+      # when a user is defining the default audience in the platform but not in the action.
       matrix:
         include:
           - audience_id: default
@@ -74,7 +74,7 @@ jobs:
               },
               "token_spec": {
                 "scope": "applied-permissions/groups:readers",
-                "expires_in": 10
+                "expires_in": 30
               }
             }'
 
@@ -104,10 +104,10 @@ jobs:
           - cli-version: latest
             audience_id: test
             audience_value: 'test-audience'
-          - cli-version: '2.74.1'
-            audience_id: github-explicit-default
             # GitHub default audience value is resolved implicitly when omitted.
             # These tests verify that the CLI handles an empty value correctly while GitHub sets the expected audience on its backend.
+          - cli-version: '2.74.1'
+            audience_id: github-explicit-default
             audience_value: ''
           - cli-version: '2.75.0'
             audience_id: github-explicit-default

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -50,7 +50,7 @@ jobs:
               "provider_type": "GitHub",
               "audience": "${{ matrix.audience_value }}",
               "enable_permissive_configuration": "true",
-              "description": "Test configuration for audience ${{ matrix.audience_value }}"
+              "description": "Temp integration for testing OIDC with audience: ${{ matrix.audience_value }}"
             }'
 
       - name: Create OIDC Identity Mapping

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -1,12 +1,19 @@
 name: OIDC Integration Test
+# This workflow tests the setup-jfrog-cli GitHub Action's OpenID Connect integration across OSes and CLI versions.
+# It ensures backward compatibility with older CLI versions and validates step outputs and connectivity.
+# CLI versions used:
+# - 2.74.1: Does not support `jf eot` command, validates manual fallback logic.
+# - 2.75.0: Introduced native OIDC token exchange.
+# - Latest: Ensures ongoing compatibility with the most recent CLI build.
 
 on:
   push:
     branches:
-      - "**"
+      - master
+  # Triggers the workflow on labeled PRs only.
   pull_request_target:
-    types: [labeled]
-
+    types: [ labeled ]
+# Ensures that only the latest commit is running for each PR at a time.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -9,7 +9,7 @@ name: OIDC Integration Test
 on:
   push:
     branches:
-      - "master"
+      - master
   # Triggers the workflow on labeled PRs only.
   pull_request_target:
     types: [ labeled ]
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  generate-oidc-integration:
+  generate-platform-oidc-integration:
     strategy:
       matrix:
         # This has to match the second audience value in the workflow, under oidc-test matrix.
@@ -76,7 +76,7 @@ jobs:
         run: echo "oidc_provider_name=${{ steps.gen-oidc.outputs.oidc_provider_name }}" >> "$GITHUB_ENV"
 
   oidc-test:
-    needs: generate-oidc-integration
+    needs: generate-platform-oidc-integration
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -31,11 +31,6 @@ jobs:
         audience_value: ['', 'test-audience']
     runs-on: ubuntu-latest
     steps:
-      - name: Generate unique OIDC provider name
-        id: gen-oidc
-        shell: bash
-        run: echo "oidc_provider_name=oidc-integration-${{ matrix.audience_value }}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
-
       - name: Create OpenID Connect integration
         shell: bash
         run: |

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -27,7 +27,7 @@ jobs:
           - audience_id: test
             audience_value: 'test-audience'
           - audience_id: github-default
-            audience_value: 'https://github.com/eyaldelarea'
+            audience_value: 'https://github.com/EyalDelarea'
     runs-on: ubuntu-latest
     steps:
       - name: Create OpenID Connect integration

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -27,6 +27,7 @@ jobs:
   generate-platform-oidc-integration:
     strategy:
       matrix:
+        # Test with a default and provided audience value
         audience_value: ['', 'test-audience']
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         cli-version: [ '2.74.1', '2.75.0','latest' ]
-        audience_value: [ '' ,'','github-jfrog' ]
+        audience_value: [ '' ,'test-audience','github-jfrog' ]
     runs-on: ${{ matrix.os }}-latest
     name: OIDC Test - ${{ matrix.cli-version }} on ${{ matrix.os }}
     env:
@@ -59,7 +59,7 @@ jobs:
               "name": "${{ steps.gen-oidc.outputs.oidc_provider_name }}",
               "issuer_url": "https://token.actions.githubusercontent.com",
               "provider_type": "GitHub",
-              "audience": ${{ matrix.audience_value }},",
+              "audience": "${{ matrix.audience_value }},",
               "enable_permissive_configuration": "true",
               "description": "Test configuration for CLI version ${{ matrix.cli-version }}"
             }'

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -90,7 +90,11 @@ class OidcUtils {
             if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
                 throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
             }
-            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience || 'jfrog-github'], { silent: true });
+            core.info("---------------------------------");
+            core.info("audience: " + creds.oidcAudience);
+            core.info("provider name: " + creds.oidcProviderName);
+            core.info("---------------------------------");
+            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience || utils_1.Utils.DEFAULT_OIDC_AUDIENCE], { silent: true });
             const { accessToken, username } = this.extractValuesFromOIDCToken(output);
             this.setOidcStepOutputs(username, accessToken);
             return accessToken;

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -64,7 +64,13 @@ class OidcUtils {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }
             // Get OIDC token ID from GitHub
-            jfrogCredentials.oidcTokenId = yield this.getIdToken(jfrogCredentials.oidcAudience);
+            try {
+                core.debug('Attempting to fetch JSON Web Token (JWT) ID token with audience value: ' + jfrogCredentials.oidcAudience);
+                jfrogCredentials.oidcTokenId = yield core.getIDToken(jfrogCredentials.oidcAudience);
+            }
+            catch (error) {
+                throw new Error(`Failed to fetch OpenID Connect JSON Web Token: ${error.message}`);
+            }
             // Version should be more than min version
             // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
             if (this.isCLIVersionOidcSupported() && !core.getInput(utils_1.Utils.CLI_REMOTE_ARG)) {
@@ -286,23 +292,6 @@ class OidcUtils {
             }
             core.debug(`config.yml found in ${configRelativePath}`);
             return yield fs_1.promises.readFile(configRelativePath, 'utf-8');
-        });
-    }
-    /**
-     * Fetches a JSON Web Token (JWT) ID token from GitHub's OIDC provider.
-     * @param audience - The intended audience for the token.
-     * @returns A promise that resolves to the JWT ID token as a string.
-     * @throws An error if fetching the token fails.
-     */
-    static getIdToken(audience) {
-        return __awaiter(this, void 0, void 0, function* () {
-            core.debug('Attempting to fetch JSON Web Token (JWT) ID token...');
-            try {
-                return yield core.getIDToken(audience);
-            }
-            catch (error) {
-                throw new Error(`Failed to fetch OpenID Connect JSON Web Token: ${error.message}`);
-            }
         });
     }
     static isCLIVersionOidcSupported() {

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -100,6 +100,7 @@ class OidcUtils {
             if (creds.oidcAudience !== "") {
                 args.push('--oidc-audience', creds.oidcAudience);
             }
+            core.debug('Running CLI command: ' + args.join(' '));
             output = yield utils_1.Utils.runCliAndGetOutput(args, { silent: true });
             const { accessToken, username } = this.extractValuesFromOIDCToken(output);
             this.setOidcStepOutputs(username, accessToken);

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -64,11 +64,7 @@ class OidcUtils {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }
             // Get OIDC token ID from GitHub
-            core.info(" THIS IS THE creds:");
-            core.info(jfrogCredentials.oidcAudience);
-            core.info(" THIS IS THE INPUT:");
-            core.info(core.getInput(utils_1.Utils.OIDC_AUDIENCE_ARG));
-            jfrogCredentials.oidcTokenId = yield this.getIdToken(core.getInput(utils_1.Utils.OIDC_AUDIENCE_ARG));
+            jfrogCredentials.oidcTokenId = yield this.getIdToken(jfrogCredentials.oidcAudience);
             // Version should be more than min version
             // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
             if (this.isCLIVersionOidcSupported() && !core.getInput(utils_1.Utils.CLI_REMOTE_ARG)) {
@@ -94,7 +90,11 @@ class OidcUtils {
             if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
                 throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
             }
-            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl], { silent: true });
+            const args = ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl];
+            if (creds.oidcAudience) {
+                args.push('--oidc-audience', creds.oidcAudience);
+            }
+            output = yield utils_1.Utils.runCliAndGetOutput(args, { silent: true });
             const { accessToken, username } = this.extractValuesFromOIDCToken(output);
             this.setOidcStepOutputs(username, accessToken);
             return accessToken;

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -64,7 +64,7 @@ class OidcUtils {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }
             // Get OIDC token ID from GitHub
-            jfrogCredentials.oidcTokenId = yield this.getIdToken(jfrogCredentials.oidcAudience || '');
+            jfrogCredentials.oidcTokenId = yield this.getIdToken(jfrogCredentials.oidcAudience);
             // Version should be more than min version
             // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
             if (this.isCLIVersionOidcSupported() && !core.getInput(utils_1.Utils.CLI_REMOTE_ARG)) {
@@ -90,11 +90,7 @@ class OidcUtils {
             if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
                 throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
             }
-            core.info("---------------------------------");
-            core.info("audience: " + creds.oidcAudience);
-            core.info("provider name: " + creds.oidcProviderName);
-            core.info("---------------------------------");
-            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience || utils_1.Utils.DEFAULT_OIDC_AUDIENCE], { silent: true });
+            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience], { silent: true });
             const { accessToken, username } = this.extractValuesFromOIDCToken(output);
             this.setOidcStepOutputs(username, accessToken);
             return accessToken;

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -64,7 +64,11 @@ class OidcUtils {
                 throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
             }
             // Get OIDC token ID from GitHub
-            jfrogCredentials.oidcTokenId = yield this.getIdToken(jfrogCredentials.oidcAudience);
+            core.info(" THIS IS THE creds:");
+            core.info(jfrogCredentials.oidcAudience);
+            core.info(" THIS IS THE INPUT:");
+            core.info(core.getInput(utils_1.Utils.OIDC_AUDIENCE_ARG));
+            jfrogCredentials.oidcTokenId = yield this.getIdToken(core.getInput(utils_1.Utils.OIDC_AUDIENCE_ARG));
             // Version should be more than min version
             // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
             if (this.isCLIVersionOidcSupported() && !core.getInput(utils_1.Utils.CLI_REMOTE_ARG)) {
@@ -90,7 +94,7 @@ class OidcUtils {
             if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
                 throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
             }
-            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience], { silent: true });
+            output = yield utils_1.Utils.runCliAndGetOutput(['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl], { silent: true });
             const { accessToken, username } = this.extractValuesFromOIDCToken(output);
             this.setOidcStepOutputs(username, accessToken);
             return accessToken;

--- a/lib/oidc-utils.js
+++ b/lib/oidc-utils.js
@@ -91,7 +91,7 @@ class OidcUtils {
                 throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
             }
             const args = ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl];
-            if (creds.oidcAudience) {
+            if (creds.oidcAudience !== "") {
                 args.push('--oidc-audience', creds.oidcAudience);
             }
             output = yield utils_1.Utils.runCliAndGetOutput(args, { silent: true });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG),
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || '',
             oidcTokenId: '',
         };
         if (jfrogCredentials.password && !jfrogCredentials.username) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || Utils.DEFAULT_OIDC_AUDIENCE,
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG),
             oidcTokenId: '',
         };
         if (jfrogCredentials.password && !jfrogCredentials.username) {
@@ -474,4 +474,3 @@ Utils.JOB_SUMMARY_DISABLE = 'disable-job-summary';
 Utils.AUTO_BUILD_PUBLISH_DISABLE = 'disable-auto-build-publish';
 // Custom server ID input
 Utils.CUSTOM_SERVER_ID = 'custom-server-id';
-Utils.DEFAULT_OIDC_AUDIENCE = 'jfrog-github';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -184,7 +184,6 @@ class Utils {
              * @name password - JFrog Platform basic authentication
              * @name accessToken - Jfrog Platform access token
              * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
-             * @name oidcAudience - JFrog Platform OpenID Connect audience
              */
             let url = jfrogCredentials.jfrogUrl;
             let user = jfrogCredentials.username;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || 'bad-default',
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || '',
             oidcTokenId: '',
         };
         if (jfrogCredentials.password && !jfrogCredentials.username) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || '',
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || 'bad-default',
             oidcTokenId: '',
         };
         if (jfrogCredentials.password && !jfrogCredentials.username) {

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -41,7 +41,7 @@ export class OidcUtils {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }
         // Get OIDC token ID from GitHub
-        jfrogCredentials.oidcTokenId = await this.getIdToken(jfrogCredentials.oidcAudience || '');
+        jfrogCredentials.oidcTokenId = await this.getIdToken(jfrogCredentials.oidcAudience);
 
         // Version should be more than min version
         // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
@@ -68,12 +68,8 @@ export class OidcUtils {
         if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
             throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
         }
-        core.info("---------------------------------")
-        core.info("audience: " + creds.oidcAudience);
-        core.info("provider name: " + creds.oidcProviderName);
-        core.info("---------------------------------")
         output = await Utils.runCliAndGetOutput(
-            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience || Utils.DEFAULT_OIDC_AUDIENCE],
+            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience],
             { silent: true },
         );
 

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -70,7 +70,7 @@ export class OidcUtils {
         }
 
         const args = ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl];
-        if (creds.oidcAudience) {
+        if (creds.oidcAudience !== "") {
             args.push('--oidc-audience', creds.oidcAudience);
         }
         output = await Utils.runCliAndGetOutput(args, { silent: true });

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -41,7 +41,12 @@ export class OidcUtils {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }
         // Get OIDC token ID from GitHub
-        jfrogCredentials.oidcTokenId = await this.getIdToken(jfrogCredentials. oidcAudience);
+        try {
+            core.debug('Attempting to fetch JSON Web Token (JWT) ID token with audience value: ' + jfrogCredentials.oidcAudience);
+            jfrogCredentials.oidcTokenId = await core.getIDToken(jfrogCredentials.oidcAudience);
+        } catch (error: any) {
+            throw new Error(`Failed to fetch OpenID Connect JSON Web Token: ${error.message}`);
+        }
 
         // Version should be more than min version
         // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
@@ -275,21 +280,6 @@ export class OidcUtils {
 
         core.debug(`config.yml found in ${configRelativePath}`);
         return await fs.readFile(configRelativePath, 'utf-8');
-    }
-
-    /**
-     * Fetches a JSON Web Token (JWT) ID token from GitHub's OIDC provider.
-     * @param audience - The intended audience for the token.
-     * @returns A promise that resolves to the JWT ID token as a string.
-     * @throws An error if fetching the token fails.
-     */
-    private static async getIdToken(audience: string): Promise<string> {
-        core.debug('Attempting to fetch JSON Web Token (JWT) ID token...');
-        try {
-            return await core.getIDToken(audience);
-        } catch (error: any) {
-            throw new Error(`Failed to fetch OpenID Connect JSON Web Token: ${error.message}`);
-        }
     }
 
     public static isCLIVersionOidcSupported(): boolean {

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -78,6 +78,7 @@ export class OidcUtils {
         if (creds.oidcAudience !== "") {
             args.push('--oidc-audience', creds.oidcAudience);
         }
+        core.debug('Running CLI command: ' + args.join(' '));
         output = await Utils.runCliAndGetOutput(args, { silent: true });
 
         const { accessToken, username }: CliExchangeTokenResponse = this.extractValuesFromOIDCToken(output);

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -41,11 +41,7 @@ export class OidcUtils {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }
         // Get OIDC token ID from GitHub
-        core.info(" THIS IS THE creds:")
-        core.info(jfrogCredentials.oidcAudience)
-        core.info(" THIS IS THE INPUT:")
-        core.info(core.getInput(Utils.OIDC_AUDIENCE_ARG))
-        jfrogCredentials.oidcTokenId = await this.getIdToken(core.getInput(Utils.OIDC_AUDIENCE_ARG));
+        jfrogCredentials.oidcTokenId = await this.getIdToken(jfrogCredentials. oidcAudience);
 
         // Version should be more than min version
         // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
@@ -72,10 +68,12 @@ export class OidcUtils {
         if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
             throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
         }
-        output = await Utils.runCliAndGetOutput(
-            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl],
-            { silent: true },
-        );
+
+        const args = ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl];
+        if (creds.oidcAudience) {
+            args.push('--oidc-audience', creds.oidcAudience);
+        }
+        output = await Utils.runCliAndGetOutput(args, { silent: true });
 
         const { accessToken, username }: CliExchangeTokenResponse = this.extractValuesFromOIDCToken(output);
         this.setOidcStepOutputs(username, accessToken);

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -41,7 +41,11 @@ export class OidcUtils {
             throw new Error(`JF_URL must be provided when oidc-provider-name is specified`);
         }
         // Get OIDC token ID from GitHub
-        jfrogCredentials.oidcTokenId = await this.getIdToken(jfrogCredentials.oidcAudience);
+        core.info(" THIS IS THE creds:")
+        core.info(jfrogCredentials.oidcAudience)
+        core.info(" THIS IS THE INPUT:")
+        core.info(core.getInput(Utils.OIDC_AUDIENCE_ARG))
+        jfrogCredentials.oidcTokenId = await this.getIdToken(core.getInput(Utils.OIDC_AUDIENCE_ARG));
 
         // Version should be more than min version
         // If CLI_REMOTE_ARG specified, we have to fetch token before we can download the CLI.
@@ -69,7 +73,7 @@ export class OidcUtils {
             throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
         }
         output = await Utils.runCliAndGetOutput(
-            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience],
+            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl],
             { silent: true },
         );
 

--- a/src/oidc-utils.ts
+++ b/src/oidc-utils.ts
@@ -68,9 +68,12 @@ export class OidcUtils {
         if (creds.oidcProviderName === undefined || creds.oidcTokenId === undefined || creds.jfrogUrl === undefined) {
             throw new Error('Missing one or more required fields: OIDC provider name, token ID, or JFrog Platform URL.');
         }
-
+        core.info("---------------------------------")
+        core.info("audience: " + creds.oidcAudience);
+        core.info("provider name: " + creds.oidcProviderName);
+        core.info("---------------------------------")
         output = await Utils.runCliAndGetOutput(
-            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience || 'jfrog-github'],
+            ['eot', creds.oidcProviderName, creds.oidcTokenId, '--url', creds.jfrogUrl, '--oidc-audience', creds.oidcAudience || Utils.DEFAULT_OIDC_AUDIENCE],
             { silent: true },
         );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface JfrogCredentials {
     accessToken?: string;
     oidcProviderName?: string;
     oidcTokenId?: string;
-    oidcAudience?: string;
+    oidcAudience : string;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,7 @@ export class Utils {
     public static readonly AUTO_BUILD_PUBLISH_DISABLE: string = 'disable-auto-build-publish';
     // Custom server ID input
     private static readonly CUSTOM_SERVER_ID: string = 'custom-server-id';
-    private static DEFAULT_OIDC_AUDIENCE: string = 'jfrog-github';
+    public static DEFAULT_OIDC_AUDIENCE: string = 'jfrog-github';
 
     /**
      * Gathers JFrog's credentials from environment variables and delivers them in a JfrogCredentials structure

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,7 +203,6 @@ export class Utils {
          * @name password - JFrog Platform basic authentication
          * @name accessToken - Jfrog Platform access token
          * @name oidcProviderName - OpenID Connect provider name defined in the JFrog Platform
-         * @name oidcAudience - JFrog Platform OpenID Connect audience
          */
         let url: string | undefined = jfrogCredentials.jfrogUrl;
         let user: string | undefined = jfrogCredentials.username;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,6 @@ export class Utils {
     public static readonly AUTO_BUILD_PUBLISH_DISABLE: string = 'disable-auto-build-publish';
     // Custom server ID input
     private static readonly CUSTOM_SERVER_ID: string = 'custom-server-id';
-    public static DEFAULT_OIDC_AUDIENCE: string = 'jfrog-github';
 
     /**
      * Gathers JFrog's credentials from environment variables and delivers them in a JfrogCredentials structure
@@ -66,7 +65,7 @@ export class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || Utils.DEFAULT_OIDC_AUDIENCE,
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG),
             oidcTokenId: '',
         } as JfrogCredentials;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,7 @@ export class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || '',
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || 'bad-default',
             oidcTokenId: '',
         } as JfrogCredentials;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,7 @@ export class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || 'bad-default',
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || '',
             oidcTokenId: '',
         } as JfrogCredentials;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,7 @@ export class Utils {
             username: process.env.JF_USER,
             password: process.env.JF_PASSWORD,
             oidcProviderName: core.getInput(Utils.OIDC_INTEGRATION_PROVIDER_NAME),
-            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG),
+            oidcAudience: core.getInput(Utils.OIDC_AUDIENCE_ARG) || '',
             oidcTokenId: '',
         } as JfrogCredentials;
 

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -127,7 +127,7 @@ describe('Collect JFrog Credentials from env vars exceptions', () => {
         expect(jfrogCredentials.accessToken).toBeUndefined();
         expect(jfrogCredentials.username).toBeUndefined();
         expect(jfrogCredentials.password).toBeUndefined();
-        expect(jfrogCredentials.oidcAudience).toBeUndefined()
+        expect(jfrogCredentials.oidcAudience).toEqual("")
     });
 });
 

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -111,6 +111,24 @@ describe('Collect JFrog Credentials from env vars exceptions', () => {
         process.env['JF_PASSWORD'] = password;
         expect(() => Utils.collectJfrogCredentialsFromEnvVars()).toThrow(new Error(exception));
     });
+
+    test('collectJfrogCredentialsFromEnvVars should return default values when no environment variables are set', () => {
+        // Ensure no relevant environment variables are set
+        delete process.env['JF_URL'];
+        delete process.env['JF_ACCESS_TOKEN'];
+        delete process.env['JF_USER'];
+        delete process.env['JF_PASSWORD'];
+
+        // Call the function
+        const jfrogCredentials: JfrogCredentials = Utils.collectJfrogCredentialsFromEnvVars();
+
+        // Verify default values
+        expect(jfrogCredentials.jfrogUrl).toBeUndefined();
+        expect(jfrogCredentials.accessToken).toBeUndefined();
+        expect(jfrogCredentials.username).toBeUndefined();
+        expect(jfrogCredentials.password).toBeUndefined();
+        expect(jfrogCredentials.oidcAudience).toBeUndefined()
+    });
 });
 
 async function testConfigCommand(expectedServerId: string) {

--- a/test/oidc-utils.spec.ts
+++ b/test/oidc-utils.spec.ts
@@ -88,6 +88,7 @@ describe('OidcUtils', (): void => {
         it('should throw if creds are missing required fields', async (): Promise<void> => {
             const incompleteCreds: JfrogCredentials = {
                 jfrogUrl: 'https://example.jfrog.io',
+                oidcAudience: ''
                 // missing provider and token ID
             };
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/setup-jfrog-cli#build-the-code) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

This PR fixes the default audience value and adds tests to verify this won't break in the future.


Enhances the OIDC integration test workflow:

1. Adds dynamic audience values in the test matrix ('', test-audience, github-jfrog).

2. Verifies that the CLI correctly behaves when no audience is supplied.

Updates typings and test cases to treat oidcAudience as optional rather than defaulted.