### PR TITLE
Fix macOS ARM64 test by updating CLI version to 2.31.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-15 ]
-        cli-version: [ "", "latest", "1.46.4" ]
+        cli-version: [ "", "latest", "2.31.0" ]
       fail-fast: false
     steps:
       # Checkout and install prerequisites


### PR DESCRIPTION
## Summary
- Updated test matrix CLI version from `1.46.4` to `2.31.0`
- Version 1.46.4 predates ARM64 mac support, causing 404 errors when running tests on `macos-15` (Apple Silicon) runners
- Version 2.31.0 has ARM64 mac binaries available

## Test plan
- GitHub Actions will automatically run the test workflow on this PR
- Verify that `macos-15` + `2.31.0` combination passes (previously failing with 404)

