### PR TITLE
fix: clean up imported JF_ENV configs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -219,14 +219,31 @@ class Utils {
      */
     static getServerIdForConfig() {
         let serverId = Utils.getCustomOrDefaultServerId();
-        // Add new serverId to the servers env var if it doesn't already exist.
-        if (Utils.getConfiguredJFrogServers().includes(serverId)) {
-            return serverId;
+        Utils.addServerIdForCleanup(serverId);
+        return serverId;
+    }
+    /**
+     * Add new serverId to the servers env var if it doesn't already exist.
+     */
+    static addServerIdForCleanup(serverId) {
+        if (!serverId || Utils.getConfiguredJFrogServers().includes(serverId)) {
+            return;
         }
         const currentValue = process.env[Utils.JFROG_CLI_SERVER_IDS_ENV_VAR];
         const newVal = currentValue ? `${currentValue};${serverId}` : serverId;
         core.exportVariable(Utils.JFROG_CLI_SERVER_IDS_ENV_VAR, newVal);
-        return serverId;
+    }
+    static getServerIdFromConfigToken(configToken) {
+        try {
+            const serverObj = JSON.parse(Buffer.from(configToken, 'base64').toString());
+            if (serverObj && typeof serverObj.serverId === 'string') {
+                return serverObj.serverId.trim();
+            }
+        }
+        catch (error) {
+            core.debug(`Could not extract server ID from JF_ENV config token: ${error}`);
+        }
+        return;
     }
     /**
      * Returns the custom server ID if provided, otherwise returns the default server ID.
@@ -304,6 +321,10 @@ class Utils {
                 // Mark the credentials as secrets to prevent them from being printed in the logs or exported to other workflows
                 core.setSecret(configToken);
                 yield Utils.runCli(cliConfigCmd.concat('import', configToken));
+                const serverId = Utils.getServerIdFromConfigToken(configToken);
+                if (serverId) {
+                    Utils.addServerIdForCleanup(serverId);
+                }
             }
             let configArgs = yield Utils.getJfrogCliConfigArgs(jfrogCredentials);
             if (configArgs) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,7 @@ export class Utils {
     }
 
     public static getGheBaseUrl(): string {
-        const v =
+        const v: string =
             core.getInput(Utils.GHE_BASE_URL_INPUT, { required: false }) || core.getInput(Utils.GHE_BASE_URL_ALIAS_INPUT, { required: false }) || '';
         return v.trim();
     }
@@ -248,14 +248,32 @@ export class Utils {
     private static getServerIdForConfig(): string {
         let serverId: string = Utils.getCustomOrDefaultServerId();
 
-        // Add new serverId to the servers env var if it doesn't already exist.
-        if (Utils.getConfiguredJFrogServers().includes(serverId)) {
-            return serverId;
+        Utils.addServerIdForCleanup(serverId);
+        return serverId;
+    }
+
+    /**
+     * Add new serverId to the servers env var if it doesn't already exist.
+     */
+    private static addServerIdForCleanup(serverId: string) {
+        if (!serverId || Utils.getConfiguredJFrogServers().includes(serverId)) {
+            return;
         }
         const currentValue: string | undefined = process.env[Utils.JFROG_CLI_SERVER_IDS_ENV_VAR];
         const newVal: string = currentValue ? `${currentValue};${serverId}` : serverId;
         core.exportVariable(Utils.JFROG_CLI_SERVER_IDS_ENV_VAR, newVal);
-        return serverId;
+    }
+
+    private static getServerIdFromConfigToken(configToken: string): string | undefined {
+        try {
+            const serverObj: any = JSON.parse(Buffer.from(configToken, 'base64').toString());
+            if (serverObj && typeof serverObj.serverId === 'string') {
+                return serverObj.serverId.trim();
+            }
+        } catch (error) {
+            core.debug(`Could not extract server ID from JF_ENV config token: ${error}`);
+        }
+        return;
     }
 
     /**
@@ -349,6 +367,10 @@ export class Utils {
             // Mark the credentials as secrets to prevent them from being printed in the logs or exported to other workflows
             core.setSecret(configToken);
             await Utils.runCli(cliConfigCmd.concat('import', configToken));
+            const serverId: string | undefined = Utils.getServerIdFromConfigToken(configToken);
+            if (serverId) {
+                Utils.addServerIdForCleanup(serverId);
+            }
         }
 
         let configArgs: string[] | undefined = await Utils.getJfrogCliConfigArgs(jfrogCredentials);

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
     ['JF_ENV_1', 'JF_ENV_2', 'ENV_JF_1', 'JF_ENV_LOCAL', 'JF_USER', 'JF_PASSWORD', 'JF_ACCESS_TOKEN'].forEach((envKey) => {
         delete process.env[envKey];
     });
+    delete process.env[Utils.JFROG_CLI_SERVER_IDS_ENV_VAR];
 });
 
 test('Get Config Tokens', async () => {
@@ -202,6 +203,20 @@ describe('JFrog CLI Configuration', () => {
         // Expect the servers env var to include both servers.
         const servers: string[] = Utils.getConfiguredJFrogServers();
         expect(servers).toStrictEqual([Utils.getRunDefaultServerId(), customServerId]);
+    });
+
+    test('Config token imports are registered for post-job cleanup', async () => {
+        myCore.exportVariable = jest.fn().mockImplementation((name: string, val: string) => {
+            process.env[name] = val;
+        });
+        const runCliMock = jest.spyOn(Utils, 'runCli').mockResolvedValue(undefined);
+        process.env.JF_ENV_LOCAL = V2_CONFIG;
+
+        await Utils.configJFrogServers({} as JfrogCredentials);
+
+        expect(runCliMock).toHaveBeenCalledWith(['config', 'import', V2_CONFIG]);
+        expect(core.exportVariable).toHaveBeenCalledWith(Utils.JFROG_CLI_SERVER_IDS_ENV_VAR, 'local');
+        expect(Utils.getConfiguredJFrogServers()).toStrictEqual(['local']);
     });
 
     test('Get default server ID', async () => {


### PR DESCRIPTION
## Summary

- Register server IDs imported from `JF_ENV_*` config tokens for post-job cleanup
- Reuse the existing `SETUP_JFROG_CLI_SERVER_IDS` cleanup registry for both config-add and config-token paths
- Add regression coverage for config-token imports and include the compiled action output

This fixes the self-hosted runner case from #339: `jf config import` succeeds, but the post step previously saw no configured server IDs and skipped cleanup.

Fixes #339.

## Verification

- `npm ci`
- `npm test -- --runTestsByPath test/main.spec.ts --runInBand`
- `npm run compile`
- `npx eslint -c .eslintrc.js src/utils.ts`
- `npx prettier --check src/utils.ts test/main.spec.ts`
- `git diff --check`

I also checked the broader commands:

- `npm run lint` currently fails on existing unrelated lint issues in `src/cleanup.ts`, `src/evidence-collection.ts`, and `src/job-summary.ts`
- `npm run format-check` currently reports existing unrelated formatting drift across multiple source/test files

This was prepared with Codex assistance and manually reviewed, with the patch kept to the config-token cleanup path.
